### PR TITLE
Block A: Identity lock — positioning memo + README identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Readiness: Block A (Identity lock)
+- `docs/POSITIONING_MEMO.md` — canonical one-line definition, public promise, non-promise list, public/experimental boundary, "not GraphRAG" explanation
+- `docs/DECISIONS.md` — ADR-014 (GraphRAGProjection rename proposed), ADR-015 (canonical project identity)
+- `README.md` — added "What It Is / What It Is Not" section, "Public vs Experimental Boundary" header, GraphRAGProjection disclaimer footnote
+- No engine behavior changes; docs-only identity lock
+
 ### Track B Generalization / Robustness Check v1
 - `worlds/tension-test-world/seed.nodes.json` — 3 new nodes: `invariant:idempotency`, `concept:knowledge-substrate`, `code_artifact:computeScope` (17 total)
 - `worlds/tension-test-world/seed.edges.json` — 4 new edges: constrains, documents, drift_against, contradicts (18 total)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,27 @@
 [![license](https://img.shields.io/npm/l/meaning-engine.svg)](https://github.com/utemix-org/meaning-engine/blob/main/LICENSE)
 [![node](https://img.shields.io/node/v/meaning-engine.svg)](https://nodejs.org)
 
-A deterministic engine for graph-based engineering knowledge, with reproducible diagnostic operators and evidence-grounded report artifacts.
+A deterministic computational substrate for graph-structured knowledge: you bring a typed semantic graph, the engine provides projection, navigation, diagnostic operators, and evidence-grounded reports.
+
+## What It Is / What It Is Not
+
+**What it is:**
+- A deterministic engine that takes a typed semantic graph and computes projections, traces, rival explanations, and gap analysis
+- World-agnostic: you bring any graph as JSON seed files — the engine provides the computational layer
+- Reproducible: same inputs always produce the same output, no hidden state, no LLM inside the core
+
+**What it is not:**
+- Not GraphRAG (no LLM entity extraction, no embeddings, no community summaries)
+- Not an ontology database or RDF store (no SPARQL, no OWL reasoning)
+- Not a UI framework (no rendering — the engine produces data structures)
+- Not a world engine (no physics, no simulation)
+- Not an autonomous reasoning agent (operators are invoked explicitly)
+
+See [POSITIONING_MEMO.md](./docs/POSITIONING_MEMO.md) for the full identity statement.
+
+## Public vs Experimental Boundary
+
+Everything in the **Stability** table below marked **stable** is covered by [SemVer](./docs/API_SURFACE_POLICY.md). Everything marked **experimental** may change without notice and is not part of the public contract.
 
 ## Quick Start
 
@@ -87,8 +107,10 @@ The engine is **world-agnostic**: you bring your own graph, the engine provides 
 | Knowledge substrate (`propose` → `evaluate` → `buildGraph`) | **stable** |
 | Engine facade (`MeaningEngine`, `WorldAdapter`, `Schema`) | **stable** |
 | CLI workflows (`runReasoningReport`, `runWorldSmokeWorkflow`) | **stable** |
-| LLMReflectionEngine, OWLProjection, GraphRAGProjection | **experimental** |
+| LLMReflectionEngine, OWLProjection, GraphRAGProjection¹ | **experimental** |
 | Internal observer / cabin workflows | **experimental** |
+
+¹ `GraphRAGProjection` is a deterministic text indexer — not related to Microsoft GraphRAG. Rename to `GraphIndexProjection` proposed ([DECISIONS.md](./docs/DECISIONS.md#adr-014)).
 
 See [API_SURFACE_POLICY.md](./docs/API_SURFACE_POLICY.md) for the full breakdown of what is covered by SemVer.
 

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,0 +1,76 @@
+# Architecture Decision Records
+
+This file records explicit naming, terminology, and architecture decisions for the Meaning Engine project.
+
+---
+
+## ADR-014: Rename `GraphRAGProjection` → `GraphIndexProjection`
+
+**Date:** 2026-03-21
+**Status:** Proposed (decision recorded; code rename deferred)
+**Track:** ME_READINESS / Block A
+
+### Context
+
+The repository contains an experimental class `GraphRAGProjection` (`src/core/GraphRAGProjection.js`). The name implies a relationship with Microsoft's [GraphRAG](https://github.com/microsoft/graphrag) pattern or the broader "GraphRAG" concept in the AI/ML community. This creates a misleading identity signal for external readers.
+
+### Actual Behavior
+
+`GraphRAGProjection` is a **deterministic text indexer with BFS context expansion**:
+
+- Builds an inverted text index over graph nodes (tokenize label/id/aliases → token map)
+- Provides `queryByText()` for token-intersection search (no embeddings, no LLM)
+- Provides `expandContext()` for BFS neighbor expansion
+- Provides `toLLMContext()` for flat JSON export (does not invoke any LLM)
+- Fully deterministic, no external dependencies
+- No entity extraction, no community summaries, no vector search
+
+None of these features correspond to the GraphRAG pattern.
+
+### Decision
+
+**Rename to `GraphIndexProjection`** to accurately describe the class behavior: deterministic graph indexing and structural search.
+
+### Implementation Plan
+
+1. Rename class and file: `GraphRAGProjection` → `GraphIndexProjection`, `GraphRAGProjection.js` → `GraphIndexProjection.js`
+2. Update all imports in `src/core/index.js`, `src/index.js`, `LLMReflectionEngine.js`, `ReflectiveProjection.js`
+3. Add a deprecated re-export alias for backward compatibility: `export { GraphIndexProjection as GraphRAGProjection }` (to be removed in next minor)
+4. Update `API_SURFACE_POLICY.md` and `README.md` references
+5. Update documentation-world seed nodes/edges (artifact IDs containing the old name)
+
+**Implementation is deferred** — this ADR records the decision. The rename will be executed in a separate task when approved.
+
+### Compatibility Note
+
+The class is classified as **experimental** (no tests, no docs, no SemVer coverage). Renaming an experimental export does not require a minor version bump under current policy. A deprecated alias will be provided for one minor release cycle as a courtesy.
+
+---
+
+## ADR-015: Canonical Project Identity — "Deterministic Computational Substrate"
+
+**Date:** 2026-03-21
+**Status:** Accepted
+**Track:** ME_READINESS / Block A
+
+### Context
+
+The project's identity has been ambiguous to external readers. Different documents emphasized different aspects (graph engine, knowledge system, semantic projection engine), and the presence of `GraphRAGProjection` in exports could suggest an LLM-powered retrieval system.
+
+### Decision
+
+The canonical one-line definition is:
+
+> **Meaning Engine** is a deterministic computational substrate for graph-structured knowledge: you bring a typed semantic graph, the engine provides projection, navigation, diagnostic operators, and evidence-grounded reports.
+
+Key identity boundaries:
+
+| It is | It is not |
+|-------|-----------|
+| Deterministic engine | Autonomous agent |
+| World-agnostic computational substrate | World engine / game engine |
+| Graph projection + operators | GraphRAG / vector search |
+| Evidence-grounded reports | LLM-powered reasoning |
+| JSON seed files as input | Ontology database / RDF store |
+
+This definition is recorded in `docs/POSITIONING_MEMO.md` and `README.md`.

--- a/docs/POSITIONING_MEMO.md
+++ b/docs/POSITIONING_MEMO.md
@@ -1,0 +1,57 @@
+# Positioning Memo
+
+## Canonical Definition
+
+> **Meaning Engine** is a deterministic computational substrate for graph-structured knowledge:
+> you bring a typed semantic graph, the engine provides projection, navigation, diagnostic operators, and evidence-grounded reports.
+
+## Public Promise
+
+Meaning Engine publicly guarantees:
+
+| Guarantee | Artifact |
+|-----------|----------|
+| A documented world input contract (JSON seed files) | [WORLD_INPUT_FORMAT.md](./WORLD_INPUT_FORMAT.md) |
+| A declared public API surface with SemVer discipline | [API_SURFACE_POLICY.md](./API_SURFACE_POLICY.md) |
+| Deterministic projection: same inputs → same output | `projectGraph`, tested |
+| Deterministic diagnostic operators over graph-structured worlds | `trace`, `compare`, `supports` |
+| Reproducible CLI workflows with explicit evidence grounding | `runReasoningReport.js` |
+| World-agnostic: you bring your own graph, the engine computes | Two reference worlds shipped |
+
+## Non-Promise List (What It Is Not)
+
+| It is not… | Why |
+|------------|-----|
+| **GraphRAG** | No LLM-powered entity extraction, no community summaries, no vector embeddings. See [explanation below](#not-graphrag). |
+| **An ontology database / RDF store** | No SPARQL, no OWL reasoning, no triple-store persistence. Graphs are loaded from flat JSON seed files. |
+| **A UI framework** | No rendering, no DOM, no components. The engine produces data structures; rendering is a separate concern. |
+| **A world engine / game engine** | No physics, no simulation loop, no spatial model. "World" here means a named knowledge graph with schema. |
+| **An autonomous reasoning agent** | No goals, no planning, no self-directed exploration. Operators are invoked explicitly by the caller. |
+
+## Public vs Experimental Boundary
+
+| Status | Scope | SemVer |
+|--------|-------|--------|
+| **Public (stable)** | GraphModel, Projection, Navigation, Knowledge Substrate, Operators (trace/compare/supports), CLI workflows, World input format | Covered: breaking changes require minor bump + CHANGELOG |
+| **Experimental** | LLMReflectionEngine, OWLProjection, GraphRAGProjection, ReflectiveProjection, Cabin (diagnostic observer), Workbench/character/domain projection modes | Not covered: may change or be removed without notice |
+| **Internal** | Test suites, operator baselines, world tools, specification directory | Implementation details — do not depend on them |
+
+Full classification: [API_SURFACE_POLICY.md](./API_SURFACE_POLICY.md).
+
+## Not GraphRAG
+
+The repository contains an experimental class called `GraphRAGProjection`. Despite the name, it has **nothing in common with Microsoft GraphRAG** or the broader "GraphRAG" pattern:
+
+| Property | Microsoft GraphRAG | Meaning Engine's `GraphRAGProjection` |
+|----------|-------------------|--------------------------------------|
+| Entity extraction | LLM-powered | None — nodes come from seed files |
+| Community summaries | LLM-generated | None |
+| Embeddings / vector search | Yes | None — token-based text index |
+| Context window assembly | LLM-optimized | Deterministic BFS expansion |
+| LLM dependency | Required | None — fully deterministic |
+
+The class is a deterministic text indexer with BFS context expansion over an existing graph. A rename to `GraphIndexProjection` is proposed (see [DECISIONS.md](./DECISIONS.md#adr-014)).
+
+## Versioning
+
+The project is at `0.y.z`. `package.json` is the single source of truth for the version. During `0.y.z`, minor bumps may contain breaking changes to the public API. See [VERSIONING.md](./VERSIONING.md).


### PR DESCRIPTION
## Goal

Produce canonical identity artifacts for engineering presentation readiness (Block A).
Docs-driven identity lock — no engine behavior changes.

Closes #1

## Non-goals

- No engine behavior changes
- No API changes
- No code rename implementation (decision recorded only)

## Changes

- **\docs/POSITIONING_MEMO.md\** (new) — canonical one-line definition, public promise, non-promise list (not GraphRAG / not ontology DB / not UI framework / not world engine / not autonomous agent), public vs experimental boundary, detailed not-GraphRAG explanation with comparison table
- **\docs/DECISIONS.md\** (new) — ADR-014: GraphRAGProjection rename to GraphIndexProjection (proposed, implementation deferred); ADR-015: canonical project identity definition
- **\README.md\** (updated) — added What It Is / What It Is Not section, Public vs Experimental Boundary header, GraphRAGProjection disclaimer footnote
- **\CHANGELOG.md\** (updated) — Readiness: Block A entry under Unreleased

## Acceptance checklist

- [x] \docs/POSITIONING_MEMO.md\ exists with all required sections
- [x] README contains identity sections
- [x] GraphRAGProjection decision recorded (ADR-014: propose rename)
- [x] \docs/DECISIONS.md\ exists
- [x] CHANGELOG entry under Unreleased
- [x] All wording grounded in current repo behavior (no unmarked roadmap claims)
- [x] No runtime/API behavior changes
- [x] Tests: 669 pass (34 suites)

Made with [Cursor](https://cursor.com)