### PR TITLE
GraphIndexProjection rename (ADR-014)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Readiness: Block C (Graph index projection rename)
+- `GraphRAGProjection` → **`GraphIndexProjection`** (file `src/core/GraphIndexProjection.js`); `GraphRAGProjection` remains a deprecated re-export alias for one minor cycle (`docs/DECISIONS.md` ADR-014)
+- `README.md`, `docs/POSITIONING_MEMO.md`, `docs/API_SURFACE_POLICY.md` — canonical naming and deprecation note
+- `LLMReflectionEngine` / `ContextAssembler` — `graphIndex` option and instance property (replacing `graphRAG`)
+- Documentation-world seeds/analysis — mechanical path/title updates for the renamed file
+
 ### Readiness: Block A (Identity lock)
 - `docs/POSITIONING_MEMO.md` — canonical one-line definition, public promise, non-promise list, public/experimental boundary, "not GraphRAG" explanation
 - `docs/DECISIONS.md` — ADR-014 (GraphRAGProjection rename proposed), ADR-015 (canonical project identity)

--- a/README.md
+++ b/README.md
@@ -107,10 +107,10 @@ The engine is **world-agnostic**: you bring your own graph, the engine provides 
 | Knowledge substrate (`propose` → `evaluate` → `buildGraph`) | **stable** |
 | Engine facade (`MeaningEngine`, `WorldAdapter`, `Schema`) | **stable** |
 | CLI workflows (`runReasoningReport`, `runWorldSmokeWorkflow`) | **stable** |
-| LLMReflectionEngine, OWLProjection, GraphRAGProjection¹ | **experimental** |
+| LLMReflectionEngine, OWLProjection, GraphIndexProjection¹ | **experimental** |
 | Internal observer / cabin workflows | **experimental** |
 
-¹ `GraphRAGProjection` is a deterministic text indexer — not related to Microsoft GraphRAG. Rename to `GraphIndexProjection` proposed ([DECISIONS.md](./docs/DECISIONS.md#adr-014)).
+¹ `GraphIndexProjection` is a deterministic text indexer (BFS + inverted token index). It is **not** Microsoft GraphRAG. The old name `GraphRAGProjection` remains exported as a deprecated alias for one minor cycle ([DECISIONS.md](./docs/DECISIONS.md#adr-014)).
 
 See [API_SURFACE_POLICY.md](./docs/API_SURFACE_POLICY.md) for the full breakdown of what is covered by SemVer.
 

--- a/docs/API_SURFACE_POLICY.md
+++ b/docs/API_SURFACE_POLICY.md
@@ -79,7 +79,7 @@ The following are present in the repository and may be exported, but are **not**
 |--------|--------|--------|
 | `LLMReflectionEngine` | `src/core/LLMReflectionEngine.js` | No tests, no docs, no public demo |
 | `OWLProjection` | `src/core/OWLProjection.js` | No tests, no docs |
-| `GraphRAGProjection` | `src/core/GraphRAGProjection.js` | No tests, no docs |
+| `GraphIndexProjection` | `src/core/GraphIndexProjection.js` | Export-only tests; no feature docs |
 | `ReflectiveProjection` | `src/core/ReflectiveProjection.js` | No tests, no docs |
 | `OwnershipGraph` | `src/core/OwnershipGraph.js` | No tests, no docs |
 | `PerformanceAuditor` | `src/core/PerformanceAudit.js` | Utility, not core contract |
@@ -107,6 +107,7 @@ The following are implementation details and should not be relied upon:
 
 | Symbol | Context | Replacement |
 |--------|---------|-------------|
+| `GraphRAGProjection` (export alias) | Same class as `GraphIndexProjection` | Use `GraphIndexProjection`. Alias removed in next minor. |
 | `links` key in `GraphModel` constructor | `new GraphModel({ nodes, links })` | Use `edges` instead. `links` still accepted as input alias but will be removed in a future minor. |
 | `links` key in `toJSON()` output | Was `{ nodes, links }` | Now `{ nodes, edges }`. No backward-compatibility shim on output. |
 

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -7,16 +7,16 @@ This file records explicit naming, terminology, and architecture decisions for t
 ## ADR-014: Rename `GraphRAGProjection` → `GraphIndexProjection`
 
 **Date:** 2026-03-21
-**Status:** Proposed (decision recorded; code rename deferred)
-**Track:** ME_READINESS / Block A
+**Status:** Implemented
+**Track:** ME_READINESS / Block A (code: Block C follow-up)
 
 ### Context
 
-The repository contains an experimental class `GraphRAGProjection` (`src/core/GraphRAGProjection.js`). The name implies a relationship with Microsoft's [GraphRAG](https://github.com/microsoft/graphrag) pattern or the broader "GraphRAG" concept in the AI/ML community. This creates a misleading identity signal for external readers.
+The repository contained an experimental class whose former name implied a relationship with Microsoft's [GraphRAG](https://github.com/microsoft/graphrag) pattern or the broader "GraphRAG" concept in the AI/ML community. That created a misleading identity signal for external readers.
 
 ### Actual Behavior
 
-`GraphRAGProjection` is a **deterministic text indexer with BFS context expansion**:
+`GraphIndexProjection` is a **deterministic text indexer with BFS context expansion**:
 
 - Builds an inverted text index over graph nodes (tokenize label/id/aliases → token map)
 - Provides `queryByText()` for token-intersection search (no embeddings, no LLM)
@@ -29,21 +29,17 @@ None of these features correspond to the GraphRAG pattern.
 
 ### Decision
 
-**Rename to `GraphIndexProjection`** to accurately describe the class behavior: deterministic graph indexing and structural search.
+**Canonical name: `GraphIndexProjection`** (`src/core/GraphIndexProjection.js`) — deterministic graph indexing and structural search.
 
-### Implementation Plan
+### Deprecation policy
 
-1. Rename class and file: `GraphRAGProjection` → `GraphIndexProjection`, `GraphRAGProjection.js` → `GraphIndexProjection.js`
-2. Update all imports in `src/core/index.js`, `src/index.js`, `LLMReflectionEngine.js`, `ReflectiveProjection.js`
-3. Add a deprecated re-export alias for backward compatibility: `export { GraphIndexProjection as GraphRAGProjection }` (to be removed in next minor)
-4. Update `API_SURFACE_POLICY.md` and `README.md` references
-5. Update documentation-world seed nodes/edges (artifact IDs containing the old name)
-
-**Implementation is deferred** — this ADR records the decision. The rename will be executed in a separate task when approved.
+- **`GraphRAGProjection`** remains available only as a **deprecated export alias** of `GraphIndexProjection` (same class identity: `GraphRAGProjection === GraphIndexProjection`).
+- Marked in source via JSDoc on the re-export in `src/core/index.js` and in this ADR.
+- **Removal:** next minor release after the one that ships this alias (one minor courtesy cycle), unless the experimental surface is revised sooner.
 
 ### Compatibility Note
 
-The class is classified as **experimental** (no tests, no docs, no SemVer coverage). Renaming an experimental export does not require a minor version bump under current policy. A deprecated alias will be provided for one minor release cycle as a courtesy.
+The class is classified as **experimental** (SemVer does not cover it). The alias exists to avoid surprising early adopters of the old symbol name; new code should import `GraphIndexProjection`.
 
 ---
 
@@ -55,7 +51,7 @@ The class is classified as **experimental** (no tests, no docs, no SemVer covera
 
 ### Context
 
-The project's identity has been ambiguous to external readers. Different documents emphasized different aspects (graph engine, knowledge system, semantic projection engine), and the presence of `GraphRAGProjection` in exports could suggest an LLM-powered retrieval system.
+The project's identity has been ambiguous to external readers. Different documents emphasized different aspects (graph engine, knowledge system, semantic projection engine), and the former misleading export name for the graph index projection could suggest an LLM-powered retrieval system.
 
 ### Decision
 

--- a/docs/POSITIONING_MEMO.md
+++ b/docs/POSITIONING_MEMO.md
@@ -33,16 +33,16 @@ Meaning Engine publicly guarantees:
 | Status | Scope | SemVer |
 |--------|-------|--------|
 | **Public (stable)** | GraphModel, Projection, Navigation, Knowledge Substrate, Operators (trace/compare/supports), CLI workflows, World input format | Covered: breaking changes require minor bump + CHANGELOG |
-| **Experimental** | LLMReflectionEngine, OWLProjection, GraphRAGProjection, ReflectiveProjection, Cabin (diagnostic observer), Workbench/character/domain projection modes | Not covered: may change or be removed without notice |
+| **Experimental** | LLMReflectionEngine, OWLProjection, GraphIndexProjection, ReflectiveProjection, Cabin (diagnostic observer), Workbench/character/domain projection modes | Not covered: may change or be removed without notice |
 | **Internal** | Test suites, operator baselines, world tools, specification directory | Implementation details — do not depend on them |
 
 Full classification: [API_SURFACE_POLICY.md](./API_SURFACE_POLICY.md).
 
 ## Not GraphRAG
 
-The repository contains an experimental class called `GraphRAGProjection`. Despite the name, it has **nothing in common with Microsoft GraphRAG** or the broader "GraphRAG" pattern:
+The experimental class **`GraphIndexProjection`** (canonical name; the former misleading name `GraphRAGProjection` is a deprecated export alias) has **nothing in common with Microsoft GraphRAG** or the broader "GraphRAG" pattern:
 
-| Property | Microsoft GraphRAG | Meaning Engine's `GraphRAGProjection` |
+| Property | Microsoft GraphRAG | Meaning Engine's `GraphIndexProjection` |
 |----------|-------------------|--------------------------------------|
 | Entity extraction | LLM-powered | None — nodes come from seed files |
 | Community summaries | LLM-generated | None |
@@ -50,7 +50,7 @@ The repository contains an experimental class called `GraphRAGProjection`. Despi
 | Context window assembly | LLM-optimized | Deterministic BFS expansion |
 | LLM dependency | Required | None — fully deterministic |
 
-The class is a deterministic text indexer with BFS context expansion over an existing graph. A rename to `GraphIndexProjection` is proposed (see [DECISIONS.md](./DECISIONS.md#adr-014)).
+The class is a deterministic text indexer with BFS context expansion over an existing graph. See [DECISIONS.md](./DECISIONS.md#adr-014) for the rename and deprecation policy.
 
 ## Versioning
 

--- a/src/core/GraphIndexProjection.js
+++ b/src/core/GraphIndexProjection.js
@@ -1,14 +1,13 @@
 /**
  * ═══════════════════════════════════════════════════════════════════════════
- * GRAPH RAG PROJECTION — Индексация и поиск по графу
+ * GRAPH INDEX PROJECTION — Индексация и поиск по графу
  * ═══════════════════════════════════════════════════════════════════════════
  * 
  * Phase 2: Core → Multi-Projection
- * P3.7: GraphRAG интеграция
  * См. repair-shop/ROADMAP.md
  * 
  * ПРИНЦИП:
- * - GraphRAG — это проекция, а не новый Core
+ * - Детерминированная текстовая индексация и BFS-расширение контекста (не GraphRAG-паттерн)
  * - Читает GraphModel, OwnershipGraph, Identity
  * - Полностью детерминированный
  * - Не использует LLM внутри
@@ -21,11 +20,11 @@
  * - Чистая индексация и поиск
  * 
  * ИСПОЛЬЗОВАНИЕ:
- * const ragProjection = new GraphRAGProjection(graphModel, ownershipGraph);
- * ragProjection.buildIndex();
- * const result = ragProjection.queryByNode("vova");
- * const context = ragProjection.expandContext(["vova"], 2);
- * const llmContext = ragProjection.toLLMContext();
+ * const indexProjection = new GraphIndexProjection(graphModel, ownershipGraph);
+ * indexProjection.buildIndex();
+ * const result = indexProjection.queryByNode("vova");
+ * const context = indexProjection.expandContext(["vova"], 2);
+ * const llmContext = indexProjection.toLLMContext();
  * 
  * ═══════════════════════════════════════════════════════════════════════════
  */
@@ -58,17 +57,18 @@ import { extractIdentityFromNode, getDisplayName } from "./Identity.js";
  */
 
 /**
- * GraphRAG-проекция для индексации и поиска по графу.
+ * Проекция графового индекса для индексации и поиска по графу.
+ * Детерминированный инвертированный индекс и BFS; без эмбеддингов и без LLM.
  * 
  * @pure Не использует LLM, не мутирует Core
  */
-export class GraphRAGProjection extends Projection {
+export class GraphIndexProjection extends Projection {
   /**
    * @param {import("./GraphModel.js").GraphModel} graphModel
    * @param {import("./OwnershipGraph.js").OwnershipGraph} [ownershipGraph]
    */
   constructor(graphModel, ownershipGraph = null) {
-    super("graphrag");
+    super("graphindex");
     
     /** @type {import("./GraphModel.js").GraphModel} */
     this.graphModel = graphModel;

--- a/src/core/LLMReflectionEngine.js
+++ b/src/core/LLMReflectionEngine.js
@@ -28,7 +28,7 @@
  */
 
 import { ReflectiveProjection } from "./ReflectiveProjection.js";
-import { GraphRAGProjection } from "./GraphRAGProjection.js";
+import { GraphIndexProjection } from "./GraphIndexProjection.js";
 import { ChangeProtocol, MUTATION_TYPE, AUTHOR_TYPE } from "./ChangeProtocol.js";
 import { GraphSnapshot, diffSnapshots } from "./GraphSnapshot.js";
 import { SCHEMA_VERSION, NODE_TYPES, EDGE_TYPES } from "./CanonicalGraphSchema.js";
@@ -68,12 +68,12 @@ export class ContextAssembler {
   /**
    * @param {Object} options
    * @param {ReflectiveProjection} options.reflective
-   * @param {GraphRAGProjection} [options.graphRAG]
+   * @param {GraphIndexProjection} [options.graphIndex]
    * @param {ChangeProtocol} [options.protocol]
    */
   constructor(options = {}) {
     this.reflective = options.reflective;
-    this.graphRAG = options.graphRAG || null;
+    this.graphIndex = options.graphIndex || null;
     this.protocol = options.protocol || null;
   }
   
@@ -654,7 +654,7 @@ export class LLMReflectionEngine {
     
     // Создаём проекции (read-only доступ к Core)
     this.reflective = new ReflectiveProjection(graphModel);
-    this.graphRAG = new GraphRAGProjection(graphModel);
+    this.graphIndex = new GraphIndexProjection(graphModel);
     
     // Создаём ChangeProtocol (для simulate, НЕ для apply)
     this.protocol = new ChangeProtocol(graph);
@@ -662,7 +662,7 @@ export class LLMReflectionEngine {
     // Компоненты
     this.contextAssembler = new ContextAssembler({
       reflective: this.reflective,
-      graphRAG: this.graphRAG,
+      graphIndex: this.graphIndex,
       protocol: this.protocol,
     });
     this.promptBuilder = new PromptBuilder();
@@ -1012,7 +1012,7 @@ export class LLMReflectionEngine {
     if (this.reflective?.invalidateCache) {
       this.reflective.invalidateCache();
     }
-    // GraphRAGProjection doesn't have invalidateCache
+    // GraphIndexProjection doesn't have invalidateCache
   }
   
   /**
@@ -1020,7 +1020,7 @@ export class LLMReflectionEngine {
    */
   destroy() {
     this.reflective.destroy();
-    this.graphRAG.destroy();
+    this.graphIndex.destroy();
     this.llmClient = null;
   }
 }

--- a/src/core/ReflectiveProjection.js
+++ b/src/core/ReflectiveProjection.js
@@ -10,7 +10,7 @@
  * ПРИНЦИП:
  * - Рефлексия = read-only
  * - Изменение = только через осознанное действие
- * - Читает Core, GraphRAGProjection, OWLProjection
+ * - Читает Core, GraphIndexProjection, OWLProjection
  * - Анализирует структуру
  * - Ничего не меняет
  * - Без LLM
@@ -287,7 +287,7 @@ export class ReflectiveProjection extends Projection {
         owlReady++;
       }
       
-      // GraphRAGProjection: нужен id, любые текстовые поля
+      // GraphIndexProjection: нужен id, любые текстовые поля
       if (node.id && (node.label || node.canonicalName || node.type)) {
         ragReady++;
       }
@@ -306,6 +306,7 @@ export class ReflectiveProjection extends Projection {
         readyNodes: owlReady,
         coverage: nodeCount > 0 ? Math.round((owlReady / nodeCount) * 100) : 0
       },
+      // legacy key name: coverage for GraphIndexProjection (not Microsoft GraphRAG)
       graphrag: {
         readyNodes: ragReady,
         coverage: nodeCount > 0 ? Math.round((ragReady / nodeCount) * 100) : 0

--- a/src/core/__tests__/GraphIndexProjection.exports.test.js
+++ b/src/core/__tests__/GraphIndexProjection.exports.test.js
@@ -1,0 +1,24 @@
+/**
+ * Export surface for GraphIndexProjection + deprecated GraphRAGProjection alias.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  GraphIndexProjection,
+  GraphRAGProjection,
+} from "../../index.js";
+import {
+  GraphIndexProjection as GraphIndexFromCore,
+  GraphRAGProjection as GraphRAGFromCore,
+} from "../index.js";
+
+describe("GraphIndexProjection exports", () => {
+  it("exports the canonical class from package and core entrypoints", () => {
+    expect(GraphIndexProjection).toBe(GraphIndexFromCore);
+    expect(typeof GraphIndexProjection).toBe("function");
+  });
+
+  it("keeps deprecated GraphRAGProjection as the same class identity", () => {
+    expect(GraphRAGProjection).toBe(GraphIndexProjection);
+    expect(GraphRAGProjection).toBe(GraphRAGFromCore);
+  });
+});

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -31,7 +31,11 @@ export { GraphModel, createContextFromState, createEmptyContext, INTENSITY } fro
 export { Projection, ProjectionRegistry, projectionRegistry } from "./Projection.js";
 export { DevProjection } from "./DevProjection.js";
 export { OWLProjection, NAMESPACES } from "./OWLProjection.js";
-export { GraphRAGProjection } from "./GraphRAGProjection.js";
+export { GraphIndexProjection } from "./GraphIndexProjection.js";
+/**
+ * @deprecated Use {@link GraphIndexProjection} instead. Experimental alias; remove in next minor release.
+ */
+export { GraphIndexProjection as GraphRAGProjection } from "./GraphIndexProjection.js";
 export { ReflectiveProjection } from "./ReflectiveProjection.js";
 
 // Structural Invariants

--- a/src/index.js
+++ b/src/index.js
@@ -62,6 +62,7 @@ export {
   DevProjection,
   OWLProjection,
   NAMESPACES,
+  GraphIndexProjection,
   GraphRAGProjection,
   ReflectiveProjection,
   

--- a/worlds/documentation-world/analysis/analysis.json
+++ b/worlds/documentation-world/analysis/analysis.json
@@ -38,7 +38,7 @@
         "→Projection.js [depends_on]",
         "→DevProjection.js [depends_on]",
         "→OWLProjection.js [depends_on]",
-        "→GraphRAGProjection.js [depends_on]"
+        "→GraphIndexProjection.js [depends_on]"
       ]
     },
     {
@@ -443,9 +443,9 @@
         "title": "RENDER_SURFACES_SPEC"
       },
       "to": {
-        "id": "code:file:src/core/GraphRAGProjection.js",
+        "id": "code:file:src/core/GraphIndexProjection.js",
         "type": "code_artifact",
-        "title": "GraphRAGProjection.js"
+        "title": "GraphIndexProjection.js"
       },
       "distance": 6,
       "pair": "spec↔code_artifact"

--- a/worlds/documentation-world/analysis/analysis.md
+++ b/worlds/documentation-world/analysis/analysis.md
@@ -46,7 +46,7 @@ No cycles of length 3–6 detected in the directed graph.
 5. **RENDER_SURFACES_SPEC** (spec) ↔ **CanonicalGraphSchema.js** (code_artifact) — distance: 7
 6. **RENDER_SURFACES_SPEC** (spec) ↔ **ChangeProtocol.js** (code_artifact) — distance: 6
 7. **RENDER_SURFACES_SPEC** (spec) ↔ **DevProjection.js** (code_artifact) — distance: 6
-8. **RENDER_SURFACES_SPEC** (spec) ↔ **GraphRAGProjection.js** (code_artifact) — distance: 6
+8. **RENDER_SURFACES_SPEC** (spec) ↔ **GraphIndexProjection.js** (code_artifact) — distance: 6
 9. **RENDER_SURFACES_SPEC** (spec) ↔ **GraphSnapshot.js** (code_artifact) — distance: 6
 10. **RENDER_SURFACES_SPEC** (spec) ↔ **Identity.js** (code_artifact) — distance: 6
 

--- a/worlds/documentation-world/seed.edges.json
+++ b/worlds/documentation-world/seed.edges.json
@@ -836,13 +836,13 @@
     "layer": "provenance"
   },
   {
-    "source": "code:file:src/core/GraphRAGProjection.js",
+    "source": "code:file:src/core/GraphIndexProjection.js",
     "target": "code:file:src/core/Projection.js",
     "type": "depends_on",
     "layer": "provenance"
   },
   {
-    "source": "code:file:src/core/GraphRAGProjection.js",
+    "source": "code:file:src/core/GraphIndexProjection.js",
     "target": "code:file:src/core/Identity.js",
     "type": "depends_on",
     "layer": "provenance"
@@ -879,7 +879,7 @@
   },
   {
     "source": "code:file:src/core/index.js",
-    "target": "code:file:src/core/GraphRAGProjection.js",
+    "target": "code:file:src/core/GraphIndexProjection.js",
     "type": "depends_on",
     "layer": "provenance"
   },
@@ -1125,7 +1125,7 @@
   },
   {
     "source": "code:file:src/core/LLMReflectionEngine.js",
-    "target": "code:file:src/core/GraphRAGProjection.js",
+    "target": "code:file:src/core/GraphIndexProjection.js",
     "type": "depends_on",
     "layer": "provenance"
   },

--- a/worlds/documentation-world/seed.nodes.json
+++ b/worlds/documentation-world/seed.nodes.json
@@ -736,11 +736,11 @@
     "status": "active"
   },
   {
-    "id": "code:file:src/core/GraphRAGProjection.js",
+    "id": "code:file:src/core/GraphIndexProjection.js",
     "type": "code_artifact",
-    "title": "GraphRAGProjection.js",
+    "title": "GraphIndexProjection.js",
     "source": "repo",
-    "path": "src/core/GraphRAGProjection.js",
+    "path": "src/core/GraphIndexProjection.js",
     "tags": [
       "module",
       "core"

--- a/worlds/documentation-world/tools/extracted.edges.json
+++ b/worlds/documentation-world/tools/extracted.edges.json
@@ -36,13 +36,13 @@
     "layer": "provenance"
   },
   {
-    "source": "code:file:src/core/GraphRAGProjection.js",
+    "source": "code:file:src/core/GraphIndexProjection.js",
     "target": "code:file:src/core/Projection.js",
     "type": "depends_on",
     "layer": "provenance"
   },
   {
-    "source": "code:file:src/core/GraphRAGProjection.js",
+    "source": "code:file:src/core/GraphIndexProjection.js",
     "target": "code:file:src/core/Identity.js",
     "type": "depends_on",
     "layer": "provenance"
@@ -79,7 +79,7 @@
   },
   {
     "source": "code:file:src/core/index.js",
-    "target": "code:file:src/core/GraphRAGProjection.js",
+    "target": "code:file:src/core/GraphIndexProjection.js",
     "type": "depends_on",
     "layer": "provenance"
   },
@@ -403,7 +403,7 @@
   },
   {
     "source": "code:file:src/core/LLMReflectionEngine.js",
-    "target": "code:file:src/core/GraphRAGProjection.js",
+    "target": "code:file:src/core/GraphIndexProjection.js",
     "type": "depends_on",
     "layer": "provenance"
   },

--- a/worlds/documentation-world/tools/extracted.nodes.json
+++ b/worlds/documentation-world/tools/extracted.nodes.json
@@ -48,11 +48,11 @@
     "status": "active"
   },
   {
-    "id": "code:file:src/core/GraphRAGProjection.js",
+    "id": "code:file:src/core/GraphIndexProjection.js",
     "type": "code_artifact",
-    "title": "GraphRAGProjection.js",
+    "title": "GraphIndexProjection.js",
     "source": "repo",
-    "path": "src/core/GraphRAGProjection.js",
+    "path": "src/core/GraphIndexProjection.js",
     "tags": [
       "module",
       "core"

--- a/worlds/documentation-world/tools/rename-map.json
+++ b/worlds/documentation-world/tools/rename-map.json
@@ -6,7 +6,7 @@
     { "old": "packages/engine/src/core/ChangeProtocol.js", "new": "src/core/ChangeProtocol.js" },
     { "old": "packages/engine/src/core/DevProjection.js", "new": "src/core/DevProjection.js" },
     { "old": "packages/engine/src/core/GraphModel.js", "new": "src/core/GraphModel.js" },
-    { "old": "packages/engine/src/core/GraphRAGProjection.js", "new": "src/core/GraphRAGProjection.js" },
+    { "old": "packages/engine/src/core/GraphRAGProjection.js", "new": "src/core/GraphIndexProjection.js" },
     { "old": "packages/engine/src/core/GraphSnapshot.js", "new": "src/core/GraphSnapshot.js" },
     { "old": "packages/engine/src/core/Identity.js", "new": "src/core/Identity.js" },
     { "old": "packages/engine/src/core/LLMReflectionEngine.js", "new": "src/core/LLMReflectionEngine.js" },


### PR DESCRIPTION
## Summary

Implements ME_READINESS Block C / ADR-014: canonical `GraphIndexProjection`, deprecated `GraphRAGProjection` alias, docs + tests.

## Closes

Closes #3

Made with [Cursor](https://cursor.com)