### PR TITLE
C2: export surface audit + package-root deprecation (GraphRAGProjection)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 ### Readiness: Block C (Graph index projection rename)
+- C2 follow-up: package root (`src/index.js`) re-exports `GraphRAGProjection` as a separate `@deprecated` export (same alias as `meaning-engine/core`); `docs/API_SURFACE_POLICY.md` — short C2 export-surface audit note
 - `GraphRAGProjection` → **`GraphIndexProjection`** (file `src/core/GraphIndexProjection.js`); `GraphRAGProjection` remains a deprecated re-export alias for one minor cycle (`docs/DECISIONS.md` ADR-014)
 - `README.md`, `docs/POSITIONING_MEMO.md`, `docs/API_SURFACE_POLICY.md` — canonical naming and deprecation note
 - `LLMReflectionEngine` / `ContextAssembler` — `graphIndex` option and instance property (replacing `graphRAG`)

--- a/docs/API_SURFACE_POLICY.md
+++ b/docs/API_SURFACE_POLICY.md
@@ -108,6 +108,12 @@ The following are implementation details and should not be relied upon:
 | Symbol | Context | Replacement |
 |--------|---------|-------------|
 | `GraphRAGProjection` (export alias) | Same class as `GraphIndexProjection` | Use `GraphIndexProjection`. Alias removed in next minor. |
+
+### C2 follow-up audit (export surface, 2026-03)
+
+- **Entry points checked:** `src/index.js` (package root `meaning-engine`), `src/core/index.js` (`meaning-engine/core`), `package.json` `exports` map.
+- **Canonical export:** `GraphIndexProjection` is the only named implementation class; `GraphRAGProjection` is re-exported only as a deprecated alias (same identity).
+- **No silent legacy paths:** no duplicate class export under the old filename; no extra barrels beyond the documented alias.
 | `links` key in `GraphModel` constructor | `new GraphModel({ nodes, links })` | Use `edges` instead. `links` still accepted as input alias but will be removed in a future minor. |
 | `links` key in `toJSON()` output | Was `{ nodes, links }` | Now `{ nodes, edges }`. No backward-compatibility shim on output. |
 

--- a/src/index.js
+++ b/src/index.js
@@ -63,7 +63,6 @@ export {
   OWLProjection,
   NAMESPACES,
   GraphIndexProjection,
-  GraphRAGProjection,
   ReflectiveProjection,
   
   // Structural Invariants
@@ -163,6 +162,11 @@ export {
   getCanonicalStatements,
   buildGraphFromStatements,
 } from "./core/index.js";
+
+/**
+ * @deprecated Use {@link GraphIndexProjection} instead. Same class as {@link GraphIndexProjection}; kept for one minor cycle per ADR-014 (`docs/DECISIONS.md`).
+ */
+export { GraphRAGProjection } from "./core/index.js";
 
 // ═══════════════════════════════════════════════════════════════════════════
 // HIGHLIGHT — Модель подсветки


### PR DESCRIPTION
Closes #5

## Goal

Narrow C2 follow-up after the GraphIndexProjection rename: align **package root** export framing with ADR-014 so `GraphRAGProjection` is explicitly `@deprecated` when importing `meaning-engine`, and record a short export-surface audit in policy docs.

## Non-goals

- No renames beyond existing alias policy
- No projection / runtime behavior changes
- No architecture refactors

## Acceptance checklist

- [x] Canonical exports unchanged; alias remains identity-equal to `GraphIndexProjection`
- [x] `@deprecated` on `GraphRAGProjection` re-export from `src/index.js`
- [x] `docs/API_SURFACE_POLICY.md` — C2 audit note
- [x] `CHANGELOG.md` — Unreleased note
- [x] `npx vitest run` — all tests pass

## Files changed

- `src/index.js` — separate deprecated re-export for `GraphRAGProjection`
- `docs/API_SURFACE_POLICY.md` — C2 follow-up subsection
- `CHANGELOG.md` — C2 bullet under Unreleased

## Audit findings

- No duplicate class or silent legacy export path; only the documented alias.
- `rename-map.json` and ADR/FAQ strings remain intentionally (historical / explanation).
