### PR TITLE
Block B1: Invariant matrix and proof obligations

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,8 @@ worlds/                  Reference worlds
 | NAV | Navigation transitions are reversible and type-safe |
 | PROJ | Projection is a pure function of (graph, focus, params) |
 
+For the full invariant-by-invariant evidence mapping, see [INVARIANT_MATRIX.md](./docs/INVARIANT_MATRIX.md). For what is proven vs. what remains as proof obligations, see [PROOF_OBLIGATIONS.md](./docs/PROOF_OBLIGATIONS.md).
+
 ## Tests
 
 ```bash

--- a/docs/INVARIANT_MATRIX.md
+++ b/docs/INVARIANT_MATRIX.md
@@ -1,0 +1,178 @@
+# Invariant Matrix
+
+This document maps every named invariant in Meaning Engine to its definition, enforcement mechanism, and evidence basis.
+
+**Evidence status definitions:**
+
+| Status | Meaning |
+|--------|---------|
+| **evidenced** | Dedicated tests verify this invariant; it passes in CI |
+| **partially evidenced** | Tested indirectly or with known gaps in coverage |
+| **intended** | Documented or implemented but no dedicated tests yet |
+
+---
+
+## KE — Knowledge Evolution Invariants
+
+Subsystem: `src/core/knowledge/`
+Defined in: [README.md](../README.md), [EPISTEMIC_LOG.md](../EPISTEMIC_LOG.md), [ARCHITECTURE.md](../ARCHITECTURE.md)
+
+| ID | Statement | Evidence type | Where evidenced | Status |
+|----|-----------|---------------|-----------------|--------|
+| KE1 | Only canonical statements produce graph nodes | Test suite | `knowledgeInvariants.test.js` — "KE1: only canonical statements build the graph"; `buildGraph.test.js` — "only canonical statements enter the graph"; `reviewWorkflow.test.js` — RW2, RW6; `verificationWorkflow.test.js` — VW2; `endToEnd.test.js` — "rejected statements do not appear in graph" | **evidenced** |
+| KE2 | Reject never mutates the graph | Test suite | `knowledgeInvariants.test.js` — "KE2: reject does not affect the graph"; `verificationWorkflow.test.js` — VW4; `reviewWorkflow.test.js` — RW4, RW5; `endToEnd.test.js` | **evidenced** |
+| KE3 | Every graph change traces to an epistemic event | Test suite + architecture | `knowledgeInvariants.test.js` — "KE3: approve deterministically adds to the graph"; `reviewWorkflow.test.js` — RW3, RW6; `verificationWorkflow.test.js` — VW3; `endToEnd.test.js` — "incremental log"; pipeline enforced by `evaluate()` → `getCanonicalStatements()` → `buildGraphFromStatements()` | **evidenced** |
+| KE4 | Evaluate is idempotent | Test suite | `knowledgeInvariants.test.js` — "KE4: repeated evaluate(log) is stable"; `evaluate.test.js` — "approve on already canonical → idempotent", "determinism: same log evaluated twice → identical result" | **evidenced** |
+| KE5 | Graph rebuild preserves ViewModel stability | Test suite (partial) | `knowledgeInvariants.test.js` — "KE5: projection remains total after any valid event sequence", edge case test; `verificationWorkflow.test.js` — VW11; `reviewWorkflow.test.js` — RW7; `buildGraph.test.js` — "graph from statements passes projectGraph"; `endToEnd.test.js` — full cycle | **partially evidenced** |
+
+### KE5 evidence gap
+
+The KE5 edge case test ("empty canonical set → projection on empty graph still total") asserts that `buildGraphFromStatements([])` yields an empty graph but does not call `projectGraph` on it. Meanwhile, `validateInputs.js` rejects empty graphs (`"graph has no nodes"`), so `projectGraph` on an empty graph returns `{ ok: false }`. The invariant holds for non-empty graphs; the edge case boundary is documented but not fully tested.
+
+---
+
+## NAV — Navigation Invariants
+
+Subsystem: `src/core/navigation/`
+Defined in: [README.md](../README.md), [ARCHITECTURE.md](../ARCHITECTURE.md), `applyTransition.js` (lines 15–19)
+
+| ID | Statement | Evidence type | Where evidenced | Status |
+|----|-----------|---------------|-----------------|--------|
+| NAV-1 | Valid transition produces valid focus | Test suite | `applyTransition.test.js` — "NAV-1: Valid transition produces valid focus" (select valid, select nonexistent, drillDown valid, drillDown from empty, drillDown nonexistent, drillUp, reset) | **evidenced** |
+| NAV-2 | DrillDown / DrillUp reversibility | Test suite | `applyTransition.test.js` — "NAV-2: DrillDown/DrillUp reversibility" (down+up restores, two down/two up, down→select→up) | **evidenced** |
+| NAV-3 | History integrity | Test suite | `applyTransition.test.js` — "NAV-3: History integrity" (drillDown adds to path, drillUp removes, select unchanged, reset clears, path length +1) | **evidenced** |
+| NAV-4 | Navigation determinism | Test suite | `applyTransition.test.js` — "NAV-4: Navigation determinism" (same focus+transition → same result, 100 repeated calls, all transition types) | **evidenced** |
+| NAV-5 | Navigation → Projection compatibility | Test suite | `applyTransition.test.js` — "NAV-5: Navigation → Projection compatibility" (after select/drillDown/drillUp/reset, `projectGraph` yields valid ViewModel) | **evidenced** |
+
+---
+
+## PROJ — Projection Invariants
+
+Subsystem: `src/core/projection/`
+Defined in: [README.md](../README.md), [ARCHITECTURE.md](../ARCHITECTURE.md), `projectGraph.js` (lines 18–22), `buildViewModel.js` (lines 117–130)
+
+| ID | Statement | Evidence type | Where evidenced | Status |
+|----|-----------|---------------|-----------------|--------|
+| INV-3 | Projection determinism: same `(graph, focus, params)` → same ViewModel | Test suite | `projectGraph.test.js` — "INV-3: Projection Determinism" (no focus, alice, root/depth 2, 100 repeated calls); `domainProjection.test.js` — Theorem 7; `workbenchProjection.test.js` — Theorem 4; `characterContext.test.js` — Theorem 8 | **evidenced** |
+| INV-7 | Projection totality: always returns ViewModel or typed error | Test suite | `projectGraph.test.js` — "INV-7: Projection Totality" (ok for valid input; ok:false for null graph, nonexistent focus, negative depth) | **evidenced** |
+| INV-1 | Schema conformance | Metadata only | `buildViewModel.js` — listed in `satisfiedInvariants`; no dedicated test | **intended** |
+| INV-2 | Identity stability | Metadata only | `buildViewModel.js` — listed in `satisfiedInvariants`; no dedicated test | **intended** |
+| INV-4 | Graph immutability (projection does not mutate input) | Architecture | `buildViewModel.js` — listed in `satisfiedInvariants`; enforced by pure-function design of all 5 pipeline steps; no dedicated mutation test | **intended** |
+
+### PROJ purity note
+
+The projection pipeline (`validateInputs → resolveFocus → computeVisibleSubgraph → deriveSemanticRoles → buildViewModel`) is implemented as a chain of pure, synchronous functions with no external I/O or shared state. Each step documents "no side effects" in its JSDoc header. INV-3 (determinism) and INV-7 (totality) are the formalized, tested projections of the PROJ invariant. INV-1, INV-2, INV-4 are declared in metadata but lack standalone tests.
+
+---
+
+## Structural — Graph Integrity Invariants
+
+Subsystem: `src/core/StructuralInvariants.js`
+Enforced via: `InvariantChecker.checkAll()`, consumed by `ChangeProtocol.ProposalValidator`
+
+### Graph invariants
+
+| ID | Statement | Evidence type | Where evidenced | Status |
+|----|-----------|---------------|-----------------|--------|
+| INV-G1 | All node IDs are unique | Implementation + integration | `StructuralInvariants.js` — `checkUniqueNodeIds()`; `ChangeProtocol` runs at `STRICTNESS.MINIMAL`; no dedicated unit test | **partially evidenced** |
+| INV-G2 | All edge IDs are unique | Implementation + integration | `StructuralInvariants.js` — `checkUniqueEdgeIds()`; `ChangeProtocol` runs at `STRICTNESS.MINIMAL` | **partially evidenced** |
+| INV-G3 | No dangling edges (source/target exist) | Implementation + integration | `StructuralInvariants.js` — `checkNoDanglingEdges()`; `ChangeProtocol` runs at `STRICTNESS.MINIMAL` | **partially evidenced** |
+| INV-G4 | No self-loops | Implementation | `StructuralInvariants.js` — `checkNoSelfLoops()`; checked at `STRICTNESS.STANDARD` | **intended** |
+
+### Identity invariants
+
+| ID | Statement | Evidence type | Where evidenced | Status |
+|----|-----------|---------------|-----------------|--------|
+| INV-I1 | All nodes have id | Implementation + integration | `StructuralInvariants.js` — `checkAllNodesHaveId()`; `ChangeProtocol` at `STRICTNESS.MINIMAL` | **partially evidenced** |
+| INV-I2 | All nodes have type | Implementation + integration | `StructuralInvariants.js` — `checkAllNodesHaveType()`; `ChangeProtocol` at `STRICTNESS.MINIMAL` | **partially evidenced** |
+| INV-I3 | All node types are known to schema | Implementation | `StructuralInvariants.js` — `checkKnownNodeTypes()`; `STRICTNESS.STRICT` only | **intended** |
+| INV-I4 | All nodes have label | Implementation | `StructuralInvariants.js` — `checkAllNodesHaveLabel()`; `STRICTNESS.STRICT` only | **intended** |
+
+### Edge invariants
+
+| ID | Statement | Evidence type | Where evidenced | Status |
+|----|-----------|---------------|-----------------|--------|
+| INV-E1 | All edges have type | Implementation | `StructuralInvariants.js` — `checkAllEdgesHaveType()`; `STRICTNESS.STANDARD` | **intended** |
+| INV-E2 | All edge types are known to schema | Implementation | `StructuralInvariants.js` — `checkKnownEdgeTypes()`; `STRICTNESS.STRICT` only | **intended** |
+| INV-E3 | No duplicate edges (same source, target, type) | Implementation | `StructuralInvariants.js` — `checkNoDuplicateEdges()`; `STRICTNESS.STRICT` only | **intended** |
+
+### Connectivity invariants
+
+| ID | Statement | Evidence type | Where evidenced | Status |
+|----|-----------|---------------|-----------------|--------|
+| INV-C1 | Graph is connected (one component) | Implementation | `StructuralInvariants.js` — `checkGraphConnected()`; `STRICTNESS.STRICT` only | **intended** |
+| INV-C2 | No isolated nodes | Implementation | `StructuralInvariants.js` — `checkNoIsolatedNodes()`; `STRICTNESS.STANDARD` | **intended** |
+| INV-C3 | Root node exists | Implementation | `StructuralInvariants.js` — `checkHasRootNode()`; `STRICTNESS.STRICT` only | **intended** |
+
+### Hierarchy invariants
+
+| ID | Statement | Evidence type | Where evidenced | Status |
+|----|-----------|---------------|-----------------|--------|
+| INV-H1 | No cycles in `contains` hierarchy | Implementation | `StructuralInvariants.js` — `checkNoContainsCycles()`; `STRICTNESS.STRICT` only | **intended** |
+| INV-H2 | Single parent in `contains` | Implementation | `StructuralInvariants.js` — `checkSingleParent()`; `STRICTNESS.STRICT` only | **intended** |
+
+### Structural invariants evidence gap
+
+All 16 structural invariants are implemented as pure checker functions and integrated into `ChangeProtocol` (which runs `STRICTNESS.MINIMAL` — G1, G2, G3, I1, I2). However, there are no dedicated unit tests for `StructuralInvariants.js`. The functions are exercised indirectly when `ChangeProtocol` validates proposals.
+
+---
+
+## OP — Operator Guarantees
+
+Subsystem: `operators/`
+Defined in: [API_SURFACE_POLICY.md](./API_SURFACE_POLICY.md), [ARCHITECTURE.md](../ARCHITECTURE.md)
+
+| ID | Statement | Evidence type | Where evidenced | Status |
+|----|-----------|---------------|-----------------|--------|
+| OP-PURE | All operators are pure functions (no side effects, no engine mutation) | Test suite | `reasoningReport.test.js` — "generating report does not mutate underlying graphs"; `documentationWorldCompare.test.js` — "deterministic output"; `documentationWorldTrace.test.js` — "deterministic output"; `documentationWorldOperatorSupports.test.js` — "deterministic outputs" | **evidenced** |
+| OP-DET | Operators produce deterministic output | Test suite | Same test files as OP-PURE; `dualWorldSmoke.test.js` — "deterministic across runs"; `reasoningReport.test.js` — "report is deterministic" | **evidenced** |
+| OP-NORANK | Compare does not rank rival paths (no bestPath/winner field) | Test suite | `documentationWorldCompare.test.js` — "no ranking — no bestPath/winner field" | **evidenced** |
+
+---
+
+## ENG — Engine Layer Guarantees
+
+Subsystem: `src/engine/`
+Defined in: `WorldInterface.js`, [API_SURFACE_POLICY.md](./API_SURFACE_POLICY.md)
+
+| ID | Statement | Evidence type | Where evidenced | Status |
+|----|-----------|---------------|-----------------|--------|
+| ENG-1 | WorldAdapter requires schemaData; throws without it | Test suite | `WorldAdapter.test.js` — "should throw without schemaData" | **evidenced** |
+| ENG-2 | Schema validates node/edge types against declared definitions | Test suite | `Schema.test.js` — isValidNodeType, isValidEdgeType, isEdgeAllowed, validateNode, validateEdge | **evidenced** |
+| ENG-3 | MeaningEngine requires a valid world; throws otherwise | Test suite | `MeaningEngine.test.js` — "should throw without world", "should throw with invalid world" | **evidenced** |
+| ENG-4 | Engine is world-agnostic (no hardcoded types) | Test suite | `WorldAdapter.test.js` — "should NOT contain hardcoded types"; `MeaningEngine.test.js` — "should NOT contain hardcoded types" | **evidenced** |
+| ENG-5 | WorldInterface contract: getSchema(), getGraph() required | Test suite | `WorldInterface.test.js` — full validation chain | **evidenced** |
+| ENG-6 | CatalogRegistry validates catalogs before loading | Test suite | `CatalogRegistry.test.js` — "should throw on invalid catalogs" | **evidenced** |
+| ENG-7 | GraphModel serialization preserves `type` and `layer` | Test suite | `MeaningEngine.test.js` — round-trip tests | **evidenced** |
+
+---
+
+## CP — Change Protocol Guarantees
+
+Subsystem: `src/core/ChangeProtocol.js`
+Defined in: `ChangeProtocol.js` header comments
+
+| ID | Statement | Evidence type | Where evidenced | Status |
+|----|-----------|---------------|-----------------|--------|
+| CP-1 | Every mutation goes through proposal → validate → apply | Architecture | `ChangeProtocol.js` — `apply()` calls `validate()` unless `skipValidation`; `simulate()` validates without applying | **intended** |
+| CP-2 | Validation checks structural invariants at MINIMAL strictness | Implementation | `ProposalValidator.validate()` runs `InvariantChecker.checkAll(graph, STRICTNESS.MINIMAL)` | **intended** |
+| CP-3 | Change history is preserved | Implementation | `ChangeProtocol.history` records every applied proposal with diff and snapshot | **intended** |
+
+### CP evidence gap
+
+`ChangeProtocol` and `ProposalValidator` have no dedicated test file. Their correctness is assumed from the composition of tested components (`StructuralInvariants`, `GraphSnapshot`), but no integration test exercises the full proposal → validate → apply → history pipeline.
+
+---
+
+## Summary Table
+
+| Family | Count | Evidenced | Partially evidenced | Intended |
+|--------|-------|-----------|---------------------|----------|
+| KE | 5 | 4 | 1 (KE5) | 0 |
+| NAV | 5 | 5 | 0 | 0 |
+| PROJ | 5 | 2 (INV-3, INV-7) | 0 | 3 (INV-1, INV-2, INV-4) |
+| Structural | 16 | 0 | 5 (G1–G3, I1–I2 via ChangeProtocol) | 11 |
+| OP | 3 | 3 | 0 | 0 |
+| ENG | 7 | 7 | 0 | 0 |
+| CP | 3 | 0 | 0 | 3 |
+| **Total** | **44** | **21** | **6** | **17** |

--- a/docs/PROOF_OBLIGATIONS.md
+++ b/docs/PROOF_OBLIGATIONS.md
@@ -1,0 +1,190 @@
+# Proof Obligations
+
+This document describes what Meaning Engine claims, what evidence currently supports those claims, what is not proven, and where future evidence is needed.
+
+For the full invariant-by-invariant breakdown, see [INVARIANT_MATRIX.md](./INVARIANT_MATRIX.md).
+
+---
+
+## 1. What the project claims
+
+Meaning Engine's public promise (from [README.md](../README.md)) is:
+
+1. A documented **world input contract** (JSON seed files with required fields)
+2. A declared **public API surface** with SemVer discipline
+3. **Deterministic** diagnostic operators over graph-structured worlds
+4. **Reproducible** CLI workflows and report artifacts with explicit evidence grounding
+
+These claims decompose into verifiable properties at three levels:
+
+| Level | What it means | How it is checked |
+|-------|--------------|-------------------|
+| **Deterministic behavior** | Same inputs always produce the same output; no hidden state, no randomness | Unit tests with repeated execution (100-call loops, idempotency checks) |
+| **Documented contract** | Public API shape, input/output formats, SemVer boundaries | API_SURFACE_POLICY.md + WORLD_INPUT_FORMAT.md + type declarations |
+| **Structural integrity** | Graph invariants hold before and after any operation | StructuralInvariants.js checker functions |
+
+---
+
+## 2. What is currently proven (by tests)
+
+### 2.1 Knowledge substrate — strong evidence
+
+The epistemic pipeline (`propose → verify → approve/reject → evaluate → buildGraph`) is the most thoroughly tested subsystem.
+
+| Property | Tests | Confidence |
+|----------|-------|------------|
+| Canonical-only graph build (KE1) | 7 tests across 4 test files | High |
+| Reject safety (KE2) | 5 tests across 3 test files | High |
+| Event causality (KE3) | 5 tests across 3 test files | High |
+| Idempotent evaluation (KE4) | 3 tests across 2 test files | High |
+| ViewModel stability after rebuild (KE5) | 6 tests; edge case gap noted | Medium-high |
+
+Evidence basis: `src/core/knowledge/__tests__/knowledgeInvariants.test.js` contains dedicated KE1–KE5 tests. Additional coverage in `evaluate.test.js`, `buildGraph.test.js`, `reviewWorkflow.test.js`, `verificationWorkflow.test.js`, `endToEnd.test.js`.
+
+### 2.2 Navigation — strong evidence
+
+| Property | Tests | Confidence |
+|----------|-------|------------|
+| Valid focus from valid transition (NAV-1) | 7 test cases | High |
+| DrillDown/DrillUp reversibility (NAV-2) | 3 test cases | High |
+| History path integrity (NAV-3) | 5 test cases | High |
+| Navigation determinism (NAV-4) | 3 tests (incl. 100-call loop) | High |
+| Navigation–Projection compatibility (NAV-5) | 5 test cases (full sequence) | High |
+
+Evidence basis: `src/core/navigation/__tests__/applyTransition.test.js` — dedicated NAV-1 through NAV-5 describe blocks.
+
+### 2.3 Projection — strong evidence (core), partial (metadata invariants)
+
+| Property | Tests | Confidence |
+|----------|-------|------------|
+| Determinism (INV-3) | 4+ tests across 4 test files (incl. 100-call loop) | High |
+| Totality (INV-7) | 4 test cases (valid + 3 error paths) | High |
+| 5-step pipeline correctness | Step-by-step tests in `projectGraph.test.js` | High |
+| Schema conformance (INV-1) | No dedicated test | Low |
+| Identity stability (INV-2) | No dedicated test | Low |
+| Graph immutability (INV-4) | Enforced by design (pure functions), not by test | Low |
+
+Evidence basis: `src/core/projection/__tests__/projectGraph.test.js` plus domain/workbench/character context test files.
+
+### 2.4 Operators — strong evidence
+
+| Property | Tests | Confidence |
+|----------|-------|------------|
+| Trace: deterministic, directed BFS | `documentationWorldTrace.test.js` | High |
+| Compare: deterministic, no ranking | `documentationWorldCompare.test.js` | High |
+| Supports: applicability checks | `documentationWorldOperatorSupports.test.js` | High |
+| Report: deterministic, no graph mutation | `reasoningReport.test.js` | High |
+| Dual-world smoke: baseline matching | `dualWorldSmoke.test.js` | High |
+
+### 2.5 Engine layer — strong evidence
+
+| Property | Tests | Confidence |
+|----------|-------|------------|
+| WorldAdapter contract | `WorldAdapter.test.js` | High |
+| Schema validation | `Schema.test.js` | High |
+| MeaningEngine facade | `MeaningEngine.test.js` | High |
+| WorldInterface contract | `WorldInterface.test.js` | High |
+| CatalogRegistry validation | `CatalogRegistry.test.js` | High |
+| World-agnostic (no hardcoded types) | Explicit anti-pattern tests | High |
+
+---
+
+## 3. What is documented but not fully proven
+
+### 3.1 Structural invariants (16 checkers, 0 dedicated tests)
+
+`StructuralInvariants.js` implements 16 invariant checkers across 5 categories (Graph, Identity, Edge, Connectivity, Hierarchy). These are well-implemented pure functions, but:
+
+- **No dedicated test file** for `StructuralInvariants.js`
+- 5 checkers (G1–G3, I1–I2) are exercised indirectly via `ChangeProtocol.ProposalValidator` at `STRICTNESS.MINIMAL`
+- 11 checkers (G4, I3–I4, E1–E3, C1–C3, H1–H2) have no known execution path in tests
+
+**Risk:** A regression in any of these checkers would not be caught by CI.
+
+### 3.2 Change Protocol (proposal → validate → apply)
+
+`ChangeProtocol.js` implements managed graph mutation with history tracking. It composes `StructuralInvariants` and `GraphSnapshot`. However:
+
+- **No dedicated test file** for `ChangeProtocol.js` or `ProposalValidator`
+- The full proposal → validate → apply → history pipeline is not integration-tested
+- `GraphSnapshot.js` immutability (`Object.freeze`) is not tested
+
+**Risk:** The mutation control mechanism — arguably the most safety-critical component — has no direct test coverage.
+
+### 3.3 Projection metadata invariants (INV-1, INV-2, INV-4)
+
+`buildViewModel.js` declares these in its `satisfiedInvariants` metadata field, but they have no standalone tests:
+
+- **INV-1 (Schema conformance):** ViewModel output conforms to a declared schema — no schema test
+- **INV-2 (Identity stability):** Node identities are preserved through projection — no identity test
+- **INV-4 (Graph immutability):** Projection does not mutate its input graph — no mutation test
+
+These properties are enforced by design (pure functions, no mutation), but a defensive test would catch regressions.
+
+### 3.4 Highlight model
+
+`src/highlight/highlightModel.js` documents itself as a pure function with no side effects, but has no test file. It is part of the public API (`meaning-engine/highlight` export path).
+
+---
+
+## 4. What is not claimed (and should not be)
+
+Per [POSITIONING_MEMO.md](./POSITIONING_MEMO.md) and the README:
+
+| Not claimed | Why |
+|-------------|-----|
+| "Engine understands knowledge" | No evidence of understanding — engine applies typed operations |
+| "Operators generalize to arbitrary graphs" | Only tested on 2 reference worlds |
+| "Projection handles all edge cases" | Empty graphs, disconnected components not fully tested |
+| "ChangeProtocol is production-ready" | No test coverage |
+| "Experimental modules are stable" | Explicitly marked experimental in API_SURFACE_POLICY.md |
+
+---
+
+## 5. Evidence gaps and suggested next proof artifacts
+
+Listed in priority order based on risk and coverage impact.
+
+### Critical (safety-relevant, no tests)
+
+| # | Gap | Suggested artifact | Impact |
+|---|-----|--------------------|--------|
+| 1 | StructuralInvariants has no dedicated tests | `src/core/__tests__/StructuralInvariants.test.js` — test each of the 16 checker functions with valid and violation cases | 16 invariants gain direct evidence |
+| 2 | ChangeProtocol has no tests | `src/core/__tests__/ChangeProtocol.test.js` — test proposal → validate → apply → history pipeline; test rejection on invariant violation; test simulate (dry-run) | Mutation safety gains direct evidence |
+| 3 | GraphSnapshot immutability not tested | Test that `Object.freeze` is applied and mutation attempts throw | Snapshot integrity |
+
+### Important (partially evidenced)
+
+| # | Gap | Suggested artifact | Impact |
+|---|-----|--------------------|--------|
+| 4 | KE5 edge case: empty graph projection | Add assertion in `knowledgeInvariants.test.js` KE5 edge case that actually calls `projectGraph` on empty graph and checks `ok: false` | KE5 fully locked |
+| 5 | INV-4 (graph immutability through projection) | Test that `projectGraph` input graph is unchanged after call | PROJ immutability proven |
+| 6 | INV-1/INV-2 (schema conformance, identity stability) | Define and test ViewModel schema contract | PROJ metadata invariants promoted from intended to evidenced |
+
+### Desirable (documentation gaps)
+
+| # | Gap | Suggested artifact | Impact |
+|---|-----|--------------------|--------|
+| 7 | Highlight model has no tests | `src/highlight/__tests__/highlightModel.test.js` | Public API coverage |
+| 8 | Cabin diagnostic pipeline evidence | Currently tracked separately in CABIN_CLAIM_POLICY.md — no overlap with this document | Experimental module |
+
+---
+
+## 6. Source-of-truth rule
+
+When evidence conflicts:
+
+1. **Current test behavior** is the strongest evidence
+2. **Current code behavior** overrides older documentation
+3. **Documentation** (README, ARCHITECTURE, this file) is explanatory framing, not normative
+
+This rule applies to all claims in this document and in [INVARIANT_MATRIX.md](./INVARIANT_MATRIX.md).
+
+---
+
+## 7. How to update this document
+
+1. When adding a new invariant: add it to INVARIANT_MATRIX.md first, then assess its evidence here
+2. When adding tests for a gap: update the evidence status in INVARIANT_MATRIX.md and remove the gap from this document
+3. Never upgrade a "not proven" item to "proven" without a passing test in CI
+4. Record the commit SHA of evidence changes in commit messages


### PR DESCRIPTION
## Summary
- Create `docs/INVARIANT_MATRIX.md`: maps all 44 named invariants across 7 families (KE, NAV, PROJ, Structural, OP, ENG, CP) to definition, enforcement, and evidence basis
- Create `docs/PROOF_OBLIGATIONS.md`: separates evidenced claims from intended/not-yet-proven properties; identifies 8 evidence gaps with prioritized next artifacts
- Add pointer from README Key Invariants section to the new evidence docs

Closes #7

## Non-goals
- No new invariants invented
- No runtime behavior changes
- No architecture rewrites
- No snapshot tests added

## Acceptance checklist
- [x] `docs/INVARIANT_MATRIX.md` exists and is grounded in current repo/tests/docs
- [x] `docs/PROOF_OBLIGATIONS.md` exists and clearly separates evidenced vs intended claims
- [x] KE / NAV / PROJ families covered (grounded)
- [x] Evidence gaps explicitly stated
- [x] No runtime/API behavior changes
- [x] All tests pass (671/671)

## Files changed
- `docs/INVARIANT_MATRIX.md` (new)
- `docs/PROOF_OBLIGATIONS.md` (new)
- `README.md` (2-line pointer added)

## Evidence basis
- `src/core/knowledge/__tests__/` (KE1-KE5)
- `src/core/navigation/__tests__/applyTransition.test.js` (NAV-1 to NAV-5)
- `src/core/projection/__tests__/` (INV-3, INV-7)
- `src/core/StructuralInvariants.js` (16 structural invariants)
- `src/core/ChangeProtocol.js` (CP-1 to CP-3)
- `operators/__tests__/` (OP-PURE, OP-DET)
- `src/engine/__tests__/` (ENG-1 to ENG-7)

Made with [Cursor](https://cursor.com)