### PR TITLE
Block B2: StructuralInvariants and ChangeProtocol tests

### DIFF
--- a/docs/INVARIANT_MATRIX.md
+++ b/docs/INVARIANT_MATRIX.md
@@ -74,46 +74,46 @@ Enforced via: `InvariantChecker.checkAll()`, consumed by `ChangeProtocol.Proposa
 
 | ID | Statement | Evidence type | Where evidenced | Status |
 |----|-----------|---------------|-----------------|--------|
-| INV-G1 | All node IDs are unique | Implementation + integration | `StructuralInvariants.js` — `checkUniqueNodeIds()`; `ChangeProtocol` runs at `STRICTNESS.MINIMAL`; no dedicated unit test | **partially evidenced** |
-| INV-G2 | All edge IDs are unique | Implementation + integration | `StructuralInvariants.js` — `checkUniqueEdgeIds()`; `ChangeProtocol` runs at `STRICTNESS.MINIMAL` | **partially evidenced** |
-| INV-G3 | No dangling edges (source/target exist) | Implementation + integration | `StructuralInvariants.js` — `checkNoDanglingEdges()`; `ChangeProtocol` runs at `STRICTNESS.MINIMAL` | **partially evidenced** |
-| INV-G4 | No self-loops | Implementation | `StructuralInvariants.js` — `checkNoSelfLoops()`; checked at `STRICTNESS.STANDARD` | **intended** |
+| INV-G1 | All node IDs are unique | Test suite | `StructuralInvariants.test.js` — "INV-G1: holds on valid/empty graph, detects duplicate"; `ChangeProtocol.test.js` — validated at `STRICTNESS.MINIMAL` | **evidenced** |
+| INV-G2 | All edge IDs are unique | Test suite | `StructuralInvariants.test.js` — "INV-G2: holds on valid, detects duplicate/missing id" | **evidenced** |
+| INV-G3 | No dangling edges (source/target exist) | Test suite | `StructuralInvariants.test.js` — "INV-G3: holds on valid, detects dangling source/target" | **evidenced** |
+| INV-G4 | No self-loops | Test suite | `StructuralInvariants.test.js` — "INV-G4: holds on valid, detects self-loop" | **evidenced** |
 
 ### Identity invariants
 
 | ID | Statement | Evidence type | Where evidenced | Status |
 |----|-----------|---------------|-----------------|--------|
-| INV-I1 | All nodes have id | Implementation + integration | `StructuralInvariants.js` — `checkAllNodesHaveId()`; `ChangeProtocol` at `STRICTNESS.MINIMAL` | **partially evidenced** |
-| INV-I2 | All nodes have type | Implementation + integration | `StructuralInvariants.js` — `checkAllNodesHaveType()`; `ChangeProtocol` at `STRICTNESS.MINIMAL` | **partially evidenced** |
-| INV-I3 | All node types are known to schema | Implementation | `StructuralInvariants.js` — `checkKnownNodeTypes()`; `STRICTNESS.STRICT` only | **intended** |
-| INV-I4 | All nodes have label | Implementation | `StructuralInvariants.js` — `checkAllNodesHaveLabel()`; `STRICTNESS.STRICT` only | **intended** |
+| INV-I1 | All nodes have id | Test suite | `StructuralInvariants.test.js` — "INV-I1: holds on valid, detects missing/empty id" | **evidenced** |
+| INV-I2 | All nodes have type | Test suite | `StructuralInvariants.test.js` — "INV-I2: holds on valid, detects missing type" | **evidenced** |
+| INV-I3 | All node types are known to schema | Test suite | `StructuralInvariants.test.js` — "INV-I3: flags all with empty NODE_TYPES, holds on empty graph". Note: `NODE_TYPES` is empty by design; checker is vacuously strict. | **evidenced** |
+| INV-I4 | All nodes have label | Test suite | `StructuralInvariants.test.js` — "INV-I4: holds on valid, detects missing/empty label" | **evidenced** |
 
 ### Edge invariants
 
 | ID | Statement | Evidence type | Where evidenced | Status |
 |----|-----------|---------------|-----------------|--------|
-| INV-E1 | All edges have type | Implementation | `StructuralInvariants.js` — `checkAllEdgesHaveType()`; `STRICTNESS.STANDARD` | **intended** |
-| INV-E2 | All edge types are known to schema | Implementation | `StructuralInvariants.js` — `checkKnownEdgeTypes()`; `STRICTNESS.STRICT` only | **intended** |
-| INV-E3 | No duplicate edges (same source, target, type) | Implementation | `StructuralInvariants.js` — `checkNoDuplicateEdges()`; `STRICTNESS.STRICT` only | **intended** |
+| INV-E1 | All edges have type | Test suite | `StructuralInvariants.test.js` — "INV-E1: holds on valid, detects missing edge type" | **evidenced** |
+| INV-E2 | All edge types are known to schema | Test suite | `StructuralInvariants.test.js` — "INV-E2: flags all with empty EDGE_TYPES, holds on empty graph". Note: same design as INV-I3. | **evidenced** |
+| INV-E3 | No duplicate edges (same source, target, type) | Test suite | `StructuralInvariants.test.js` — "INV-E3: holds on valid, detects duplicate, allows different types" | **evidenced** |
 
 ### Connectivity invariants
 
 | ID | Statement | Evidence type | Where evidenced | Status |
 |----|-----------|---------------|-----------------|--------|
-| INV-C1 | Graph is connected (one component) | Implementation | `StructuralInvariants.js` — `checkGraphConnected()`; `STRICTNESS.STRICT` only | **intended** |
-| INV-C2 | No isolated nodes | Implementation | `StructuralInvariants.js` — `checkNoIsolatedNodes()`; `STRICTNESS.STANDARD` | **intended** |
-| INV-C3 | Root node exists | Implementation | `StructuralInvariants.js` — `checkHasRootNode()`; `STRICTNESS.STRICT` only | **intended** |
+| INV-C1 | Graph is connected (one component) | Test suite | `StructuralInvariants.test.js` — "INV-C1: holds on connected/empty graph, detects disconnected" | **evidenced** |
+| INV-C2 | No isolated nodes | Test suite | `StructuralInvariants.test.js` — "INV-C2: holds on valid, detects isolated node" | **evidenced** |
+| INV-C3 | Root node exists | Test suite | `StructuralInvariants.test.js` — "INV-C3: always fails with empty NODE_TYPES; holds with matching type". Note: depends on world schema. | **evidenced** |
 
 ### Hierarchy invariants
 
 | ID | Statement | Evidence type | Where evidenced | Status |
 |----|-----------|---------------|-----------------|--------|
-| INV-H1 | No cycles in `contains` hierarchy | Implementation | `StructuralInvariants.js` — `checkNoContainsCycles()`; `STRICTNESS.STRICT` only | **intended** |
-| INV-H2 | Single parent in `contains` | Implementation | `StructuralInvariants.js` — `checkSingleParent()`; `STRICTNESS.STRICT` only | **intended** |
+| INV-H1 | No cycles in `contains` hierarchy | Test suite | `StructuralInvariants.test.js` — "INV-H1: holds vacuously with typed edges, detects cycle, holds on acyclic" | **evidenced** |
+| INV-H2 | Single parent in `contains` | Test suite | `StructuralInvariants.test.js` — "INV-H2: holds vacuously, detects multiple parents" | **evidenced** |
 
-### Structural invariants evidence gap
+### Structural invariants note
 
-All 16 structural invariants are implemented as pure checker functions and integrated into `ChangeProtocol` (which runs `STRICTNESS.MINIMAL` — G1, G2, G3, I1, I2). However, there are no dedicated unit tests for `StructuralInvariants.js`. The functions are exercised indirectly when `ChangeProtocol` validates proposals.
+All 16 structural invariants now have dedicated unit tests in `StructuralInvariants.test.js` (48 tests). Schema-dependent checkers (INV-I3, INV-E2, INV-C3) behave vacuously with the default empty `NODE_TYPES`/`EDGE_TYPES` — this is by design, as worlds override types via `WorldAdapter`. Tests document this behavior explicitly.
 
 ---
 
@@ -154,13 +154,18 @@ Defined in: `ChangeProtocol.js` header comments
 
 | ID | Statement | Evidence type | Where evidenced | Status |
 |----|-----------|---------------|-----------------|--------|
-| CP-1 | Every mutation goes through proposal → validate → apply | Architecture | `ChangeProtocol.js` — `apply()` calls `validate()` unless `skipValidation`; `simulate()` validates without applying | **intended** |
-| CP-2 | Validation checks structural invariants at MINIMAL strictness | Implementation | `ProposalValidator.validate()` runs `InvariantChecker.checkAll(graph, STRICTNESS.MINIMAL)` | **intended** |
-| CP-3 | Change history is preserved | Implementation | `ChangeProtocol.history` records every applied proposal with diff and snapshot | **intended** |
+| CP-1 | Every mutation goes through proposal → validate → apply | Test suite | `ChangeProtocol.test.js` — happy path (add/remove/update node, add/remove edge, batch); rejection on invalid proposals; simulate path | **evidenced** |
+| CP-2 | Validation checks structural invariants at MINIMAL strictness | Test suite | `ChangeProtocol.test.js` — "validates at MINIMAL strictness (5 checks)"; schema validation via `SchemaValidator` static calls | **evidenced** |
+| CP-3 | Change history is preserved | Test suite | `ChangeProtocol.test.js` — "records each applied proposal in history"; "failed apply does not add to history"; "snapshots grow with each apply"; "history diff captures added node"; "exportHistory returns structured data" | **evidenced** |
 
-### CP evidence gap
+### CP bugs found and fixed in B2
 
-`ChangeProtocol` and `ProposalValidator` have no dedicated test file. Their correctness is assumed from the composition of tested components (`StructuralInvariants`, `GraphSnapshot`), but no integration test exercises the full proposal → validate → apply → history pipeline.
+Four bugs were discovered in `ProposalValidator` during test development:
+
+1. **Static method called on instance:** `this.schemaValidator.validateNode(node)` — `SchemaValidator.validateNode` is static, calling on instance throws TypeError. Fixed: call `SchemaValidator.validateNode(node)` directly.
+2. **Count checked as boolean:** `!invariantResult.passed` checks count (number), not validity (boolean). Fixed: `!invariantResult.valid`.
+3. **Number iterated as array:** `for (const failure of invariantResult.failed)` — `failed` is a count. Fixed: `invariantResult.violations`.
+4. **Wrong property name:** `failure.error` — InvariantResult has `message`, not `error`. Fixed: `failure.message`.
 
 ---
 
@@ -171,8 +176,8 @@ Defined in: `ChangeProtocol.js` header comments
 | KE | 5 | 4 | 1 (KE5) | 0 |
 | NAV | 5 | 5 | 0 | 0 |
 | PROJ | 5 | 2 (INV-3, INV-7) | 0 | 3 (INV-1, INV-2, INV-4) |
-| Structural | 16 | 0 | 5 (G1–G3, I1–I2 via ChangeProtocol) | 11 |
+| Structural | 16 | 16 | 0 | 0 |
 | OP | 3 | 3 | 0 | 0 |
 | ENG | 7 | 7 | 0 | 0 |
-| CP | 3 | 0 | 0 | 3 |
-| **Total** | **44** | **21** | **6** | **17** |
+| CP | 3 | 3 | 0 | 0 |
+| **Total** | **44** | **40** | **1** | **3** |

--- a/docs/PROOF_OBLIGATIONS.md
+++ b/docs/PROOF_OBLIGATIONS.md
@@ -91,25 +91,13 @@ Evidence basis: `src/core/projection/__tests__/projectGraph.test.js` plus domain
 
 ## 3. What is documented but not fully proven
 
-### 3.1 Structural invariants (16 checkers, 0 dedicated tests)
+### ~~3.1 Structural invariants~~ — CLOSED in B2
 
-`StructuralInvariants.js` implements 16 invariant checkers across 5 categories (Graph, Identity, Edge, Connectivity, Hierarchy). These are well-implemented pure functions, but:
+All 16 checkers now have dedicated tests (48 tests in `StructuralInvariants.test.js`). Status upgraded from intended/partially evidenced to **evidenced**.
 
-- **No dedicated test file** for `StructuralInvariants.js`
-- 5 checkers (G1–G3, I1–I2) are exercised indirectly via `ChangeProtocol.ProposalValidator` at `STRICTNESS.MINIMAL`
-- 11 checkers (G4, I3–I4, E1–E3, C1–C3, H1–H2) have no known execution path in tests
+### ~~3.2 Change Protocol~~ — CLOSED in B2
 
-**Risk:** A regression in any of these checkers would not be caught by CI.
-
-### 3.2 Change Protocol (proposal → validate → apply)
-
-`ChangeProtocol.js` implements managed graph mutation with history tracking. It composes `StructuralInvariants` and `GraphSnapshot`. However:
-
-- **No dedicated test file** for `ChangeProtocol.js` or `ProposalValidator`
-- The full proposal → validate → apply → history pipeline is not integration-tested
-- `GraphSnapshot.js` immutability (`Object.freeze`) is not tested
-
-**Risk:** The mutation control mechanism — arguably the most safety-critical component — has no direct test coverage.
+Full pipeline tested (36 tests in `ChangeProtocol.test.js`): happy path, rejection, simulate, history, strictness. Four bugs discovered and fixed in `ProposalValidator` (see INVARIANT_MATRIX.md for details). Status upgraded to **evidenced**.
 
 ### 3.3 Projection metadata invariants (INV-1, INV-2, INV-4)
 
@@ -136,7 +124,7 @@ Per [POSITIONING_MEMO.md](./POSITIONING_MEMO.md) and the README:
 | "Engine understands knowledge" | No evidence of understanding — engine applies typed operations |
 | "Operators generalize to arbitrary graphs" | Only tested on 2 reference worlds |
 | "Projection handles all edge cases" | Empty graphs, disconnected components not fully tested |
-| "ChangeProtocol is production-ready" | No test coverage |
+| "ChangeProtocol is production-ready" | Tested but experimental; schema-dependent checkers use empty default types |
 | "Experimental modules are stable" | Explicitly marked experimental in API_SURFACE_POLICY.md |
 
 ---
@@ -145,28 +133,25 @@ Per [POSITIONING_MEMO.md](./POSITIONING_MEMO.md) and the README:
 
 Listed in priority order based on risk and coverage impact.
 
-### Critical (safety-relevant, no tests)
+### ~~Critical~~ — CLOSED in B2
+
+Gaps #1 (StructuralInvariants) and #2 (ChangeProtocol) are now closed with dedicated test suites. See B2 PR for details.
+
+### Important (remaining)
 
 | # | Gap | Suggested artifact | Impact |
 |---|-----|--------------------|--------|
-| 1 | StructuralInvariants has no dedicated tests | `src/core/__tests__/StructuralInvariants.test.js` — test each of the 16 checker functions with valid and violation cases | 16 invariants gain direct evidence |
-| 2 | ChangeProtocol has no tests | `src/core/__tests__/ChangeProtocol.test.js` — test proposal → validate → apply → history pipeline; test rejection on invariant violation; test simulate (dry-run) | Mutation safety gains direct evidence |
-| 3 | GraphSnapshot immutability not tested | Test that `Object.freeze` is applied and mutation attempts throw | Snapshot integrity |
-
-### Important (partially evidenced)
-
-| # | Gap | Suggested artifact | Impact |
-|---|-----|--------------------|--------|
-| 4 | KE5 edge case: empty graph projection | Add assertion in `knowledgeInvariants.test.js` KE5 edge case that actually calls `projectGraph` on empty graph and checks `ok: false` | KE5 fully locked |
-| 5 | INV-4 (graph immutability through projection) | Test that `projectGraph` input graph is unchanged after call | PROJ immutability proven |
-| 6 | INV-1/INV-2 (schema conformance, identity stability) | Define and test ViewModel schema contract | PROJ metadata invariants promoted from intended to evidenced |
+| 1 | GraphSnapshot immutability not tested | Test that `Object.freeze` is applied and mutation attempts throw | Snapshot integrity |
+| 2 | KE5 edge case: empty graph projection | Add assertion in `knowledgeInvariants.test.js` KE5 edge case that actually calls `projectGraph` on empty graph and checks `ok: false` | KE5 fully locked |
+| 3 | INV-4 (graph immutability through projection) | Test that `projectGraph` input graph is unchanged after call | PROJ immutability proven |
+| 4 | INV-1/INV-2 (schema conformance, identity stability) | Define and test ViewModel schema contract | PROJ metadata invariants promoted from intended to evidenced |
 
 ### Desirable (documentation gaps)
 
 | # | Gap | Suggested artifact | Impact |
 |---|-----|--------------------|--------|
-| 7 | Highlight model has no tests | `src/highlight/__tests__/highlightModel.test.js` | Public API coverage |
-| 8 | Cabin diagnostic pipeline evidence | Currently tracked separately in CABIN_CLAIM_POLICY.md — no overlap with this document | Experimental module |
+| 5 | Highlight model has no tests | `src/highlight/__tests__/highlightModel.test.js` | Public API coverage |
+| 6 | Cabin diagnostic pipeline evidence | Currently tracked separately in CABIN_CLAIM_POLICY.md — no overlap with this document | Experimental module |
 
 ---
 

--- a/src/core/ChangeProtocol.js
+++ b/src/core/ChangeProtocol.js
@@ -132,7 +132,6 @@ function generateProposalId() {
  */
 export class ProposalValidator {
   constructor() {
-    this.schemaValidator = new SchemaValidator();
     this.invariantChecker = new InvariantChecker();
   }
   
@@ -185,12 +184,12 @@ export class ProposalValidator {
       STRICTNESS.MINIMAL
     );
     
-    if (!invariantResult.passed) {
-      for (const failure of invariantResult.failed) {
+    if (!invariantResult.valid) {
+      for (const failure of invariantResult.violations) {
         errors.push({
           code: "INVARIANT_VIOLATION",
           invariant: failure.name,
-          message: failure.error || `Invariant ${failure.name} failed`,
+          message: failure.message || `Invariant ${failure.name} failed`,
         });
       }
     }
@@ -378,16 +377,12 @@ export class ProposalValidator {
       case MUTATION_TYPE.UPDATE_NODE: {
         const node = simulatedGraph.nodes.find(n => n.id === proposal.payload.id);
         if (node) {
-          const result = this.schemaValidator.validateNode(node);
+          const result = SchemaValidator.validateNode(node);
           if (!result.valid) {
             errors.push(...result.errors.map(e => ({
               code: "SCHEMA_ERROR",
-              field: e.field,
-              message: e.message,
+              message: e,
             })));
-          }
-          if (result.warnings) {
-            warnings.push(...result.warnings);
           }
         }
         break;
@@ -398,12 +393,11 @@ export class ProposalValidator {
         const edgeId = proposal.payload.id || simulatedGraph.edges[simulatedGraph.edges.length - 1]?.id;
         const edge = simulatedGraph.edges.find(e => e.id === edgeId);
         if (edge) {
-          const result = this.schemaValidator.validateEdge(edge);
+          const result = SchemaValidator.validateEdge(edge);
           if (!result.valid) {
             errors.push(...result.errors.map(e => ({
               code: "SCHEMA_ERROR",
-              field: e.field,
-              message: e.message,
+              message: e,
             })));
           }
         }

--- a/src/core/__tests__/ChangeProtocol.test.js
+++ b/src/core/__tests__/ChangeProtocol.test.js
@@ -1,0 +1,474 @@
+import { describe, it, expect } from "vitest";
+import {
+  ChangeProtocol,
+  ProposalValidator,
+  createProposal,
+  MUTATION_TYPE,
+  AUTHOR_TYPE,
+  PROPOSAL_STATUS,
+} from "../ChangeProtocol.js";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function seedGraph() {
+  return {
+    nodes: [
+      { id: "a", type: "concept", label: "Alpha" },
+      { id: "b", type: "concept", label: "Beta" },
+    ],
+    edges: [
+      { id: "e1", source: "a", target: "b", type: "defines" },
+    ],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// createProposal
+// ---------------------------------------------------------------------------
+
+describe("createProposal", () => {
+  it("creates a valid proposal with defaults", () => {
+    const p = createProposal({
+      type: MUTATION_TYPE.ADD_NODE,
+      payload: { id: "c", type: "spec", label: "Gamma" },
+    });
+    expect(p.id).toMatch(/^prop-/);
+    expect(p.type).toBe(MUTATION_TYPE.ADD_NODE);
+    expect(p.status).toBe(PROPOSAL_STATUS.PENDING);
+    expect(p.author).toBe(AUTHOR_TYPE.HUMAN);
+    expect(p.rationale).toBe("");
+  });
+
+  it("throws on invalid mutation type", () => {
+    expect(() => createProposal({ type: "bogus", payload: {} })).toThrow("Invalid mutation type");
+  });
+
+  it("throws without payload", () => {
+    expect(() => createProposal({ type: MUTATION_TYPE.ADD_NODE })).toThrow("Payload is required");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ProposalValidator — structure checks
+// ---------------------------------------------------------------------------
+
+describe("ProposalValidator — structure", () => {
+  const validator = new ProposalValidator();
+
+  it("rejects proposal without type", () => {
+    const result = validator.validate({ payload: {} }, seedGraph());
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.code === "MISSING_TYPE")).toBe(true);
+  });
+
+  it("rejects ADD_NODE without node id", () => {
+    const p = createProposal({ type: MUTATION_TYPE.ADD_NODE, payload: { type: "spec" } });
+    const result = validator.validate(p, seedGraph());
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.code === "MISSING_NODE_ID")).toBe(true);
+  });
+
+  it("rejects REMOVE_NODE without node id", () => {
+    const p = createProposal({ type: MUTATION_TYPE.REMOVE_NODE, payload: {} });
+    const result = validator.validate(p, seedGraph());
+    expect(result.valid).toBe(false);
+  });
+
+  it("rejects UPDATE_NODE without changes", () => {
+    const p = createProposal({ type: MUTATION_TYPE.UPDATE_NODE, payload: { id: "a" } });
+    const result = validator.validate(p, seedGraph());
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.code === "MISSING_CHANGES")).toBe(true);
+  });
+
+  it("rejects ADD_EDGE without source or target", () => {
+    const p = createProposal({ type: MUTATION_TYPE.ADD_EDGE, payload: { type: "defines" } });
+    const result = validator.validate(p, seedGraph());
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.code === "MISSING_EDGE_ENDPOINTS")).toBe(true);
+  });
+
+  it("rejects BATCH without mutations array", () => {
+    const p = createProposal({ type: MUTATION_TYPE.BATCH, payload: {} });
+    const result = validator.validate(p, seedGraph());
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.code === "INVALID_BATCH")).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ProposalValidator — simulation errors
+// ---------------------------------------------------------------------------
+
+describe("ProposalValidator — simulation", () => {
+  const validator = new ProposalValidator();
+
+  it("rejects adding a node with duplicate id", () => {
+    const p = createProposal({
+      type: MUTATION_TYPE.ADD_NODE,
+      payload: { id: "a", type: "spec", label: "Duplicate" },
+    });
+    const result = validator.validate(p, seedGraph());
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.code === "SIMULATION_FAILED")).toBe(true);
+  });
+
+  it("rejects removing a nonexistent node", () => {
+    const p = createProposal({
+      type: MUTATION_TYPE.REMOVE_NODE,
+      payload: { id: "nonexistent" },
+    });
+    const result = validator.validate(p, seedGraph());
+    expect(result.valid).toBe(false);
+  });
+
+  it("rejects adding edge with nonexistent source", () => {
+    const p = createProposal({
+      type: MUTATION_TYPE.ADD_EDGE,
+      payload: { id: "e2", source: "missing", target: "a", type: "defines" },
+    });
+    const result = validator.validate(p, seedGraph());
+    expect(result.valid).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ProposalValidator — invariant checking
+// ---------------------------------------------------------------------------
+
+describe("ProposalValidator — invariant checks", () => {
+  const validator = new ProposalValidator();
+
+  it("rejects proposal that creates dangling edge", () => {
+    const graph = {
+      nodes: [{ id: "a", type: "concept" }, { id: "b", type: "concept" }],
+      edges: [{ id: "e1", source: "a", target: "b", type: "defines" }],
+    };
+    const p = createProposal({
+      type: MUTATION_TYPE.REMOVE_NODE,
+      payload: { id: "b" },
+    });
+    // Removing "b" also removes edge e1 (implemented in _simulateApply),
+    // so this should NOT cause dangling edges.
+    const result = validator.validate(p, graph);
+    expect(result.valid).toBe(true);
+  });
+
+  it("validates add-node with schema (static call fix)", () => {
+    const p = createProposal({
+      type: MUTATION_TYPE.ADD_NODE,
+      payload: { id: "c", type: "spec", label: "Gamma" },
+    });
+    const result = validator.validate(p, seedGraph());
+    expect(result.valid).toBe(true);
+    expect(result.schemaResult).toBeDefined();
+  });
+
+  it("validates add-edge with schema (static call fix)", () => {
+    const p = createProposal({
+      type: MUTATION_TYPE.ADD_EDGE,
+      payload: { id: "e2", source: "b", target: "a", type: "implements" },
+    });
+    const result = validator.validate(p, seedGraph());
+    expect(result.valid).toBe(true);
+    expect(result.schemaResult).toBeDefined();
+  });
+
+  it("schema validation rejects node without type", () => {
+    const p = createProposal({
+      type: MUTATION_TYPE.ADD_NODE,
+      payload: { id: "c", label: "No type" },
+    });
+    const result = validator.validate(p, seedGraph());
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.code === "SCHEMA_ERROR")).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ChangeProtocol — happy path
+// ---------------------------------------------------------------------------
+
+describe("ChangeProtocol — happy path", () => {
+  it("add node: validate → apply → graph updated", () => {
+    const cp = new ChangeProtocol(seedGraph());
+    const p = cp.proposeAddNode(
+      { id: "c", type: "spec", label: "Gamma" },
+      "add spec node",
+    );
+
+    const result = cp.apply(p);
+    expect(result.success).toBe(true);
+    expect(result.errors).toHaveLength(0);
+
+    const graph = cp.getGraph();
+    expect(graph.nodes).toHaveLength(3);
+    expect(graph.nodes.find(n => n.id === "c")).toBeDefined();
+  });
+
+  it("remove node: graph shrinks and related edges removed", () => {
+    const cp = new ChangeProtocol(seedGraph());
+    const p = cp.proposeRemoveNode("b", "remove beta");
+
+    const result = cp.apply(p);
+    expect(result.success).toBe(true);
+
+    const graph = cp.getGraph();
+    expect(graph.nodes).toHaveLength(1);
+    expect(graph.edges).toHaveLength(0);
+  });
+
+  it("update node: label changed", () => {
+    const cp = new ChangeProtocol(seedGraph());
+    const p = cp.proposeUpdateNode("a", { label: "Alpha Prime" }, "rename");
+
+    const result = cp.apply(p);
+    expect(result.success).toBe(true);
+
+    const graph = cp.getGraph();
+    expect(graph.nodes.find(n => n.id === "a").label).toBe("Alpha Prime");
+  });
+
+  it("add edge: new connection created", () => {
+    const cp = new ChangeProtocol(seedGraph());
+    const p = cp.proposeAddEdge(
+      { id: "e2", source: "b", target: "a", type: "implements" },
+      "add reverse edge",
+    );
+
+    const result = cp.apply(p);
+    expect(result.success).toBe(true);
+
+    const graph = cp.getGraph();
+    expect(graph.edges).toHaveLength(2);
+  });
+
+  it("remove edge: edge deleted", () => {
+    const cp = new ChangeProtocol(seedGraph());
+    const p = cp.proposeRemoveEdge("e1", "remove defines");
+
+    const result = cp.apply(p);
+    expect(result.success).toBe(true);
+
+    const graph = cp.getGraph();
+    expect(graph.edges).toHaveLength(0);
+  });
+
+  it("batch: multiple mutations in one proposal", () => {
+    const cp = new ChangeProtocol(seedGraph());
+    const p = cp.proposeBatch([
+      { type: MUTATION_TYPE.ADD_NODE, payload: { id: "c", type: "spec", label: "Gamma" } },
+      { type: MUTATION_TYPE.ADD_EDGE, payload: { id: "e2", source: "a", target: "c", type: "implements" } },
+    ], "batch add");
+
+    const result = cp.apply(p);
+    expect(result.success).toBe(true);
+
+    const graph = cp.getGraph();
+    expect(graph.nodes).toHaveLength(3);
+    expect(graph.edges).toHaveLength(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ChangeProtocol — rejection
+// ---------------------------------------------------------------------------
+
+describe("ChangeProtocol — rejection", () => {
+  it("apply rejects invalid proposal and does not modify graph", () => {
+    const cp = new ChangeProtocol(seedGraph());
+    const p = cp.proposeAddNode(
+      { id: "a", type: "concept", label: "Duplicate" },
+      "should fail",
+    );
+
+    const result = cp.apply(p);
+    expect(result.success).toBe(false);
+    expect(result.errors.length).toBeGreaterThan(0);
+
+    const graph = cp.getGraph();
+    expect(graph.nodes).toHaveLength(2);
+  });
+
+  it("proposal status is set to REJECTED on validation failure", () => {
+    const cp = new ChangeProtocol(seedGraph());
+    const p = cp.proposeRemoveNode("nonexistent", "should fail");
+
+    cp.validate(p);
+    expect(p.status).toBe(PROPOSAL_STATUS.REJECTED);
+  });
+
+  it("proposal status is set to VALIDATED on success", () => {
+    const cp = new ChangeProtocol(seedGraph());
+    const p = cp.proposeAddNode(
+      { id: "c", type: "spec", label: "Gamma" },
+      "should pass",
+    );
+
+    cp.validate(p);
+    expect(p.status).toBe(PROPOSAL_STATUS.VALIDATED);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ChangeProtocol — simulate (dry-run)
+// ---------------------------------------------------------------------------
+
+describe("ChangeProtocol — simulate", () => {
+  it("simulate returns diff without modifying graph", () => {
+    const cp = new ChangeProtocol(seedGraph());
+    const p = cp.proposeAddNode(
+      { id: "c", type: "spec", label: "Gamma" },
+      "dry-run",
+    );
+
+    const result = cp.simulate(p);
+    expect(result.valid).toBe(true);
+    expect(result.diff).toBeDefined();
+    expect(result.diff.summary.nodesAdded).toBe(1);
+    expect(result.diff.summary.hasChanges).toBe(true);
+
+    expect(p.status).toBe(PROPOSAL_STATUS.SIMULATED);
+
+    const graph = cp.getGraph();
+    expect(graph.nodes).toHaveLength(2);
+  });
+
+  it("simulate returns errors on invalid proposal", () => {
+    const cp = new ChangeProtocol(seedGraph());
+    const p = cp.proposeAddNode(
+      { id: "a", type: "concept" },
+      "duplicate",
+    );
+
+    const result = cp.simulate(p);
+    expect(result.valid).toBe(false);
+    expect(result.simulatedGraph).toBeNull();
+    expect(result.errors.length).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ChangeProtocol — history
+// ---------------------------------------------------------------------------
+
+describe("ChangeProtocol — history", () => {
+  it("records each applied proposal in history", () => {
+    const cp = new ChangeProtocol(seedGraph());
+
+    const p1 = cp.proposeAddNode({ id: "c", type: "spec", label: "C" }, "first");
+    cp.apply(p1);
+
+    const p2 = cp.proposeAddNode({ id: "d", type: "spec", label: "D" }, "second");
+    cp.apply(p2);
+
+    const history = cp.getHistory();
+    expect(history).toHaveLength(2);
+    expect(history[0].proposal.rationale).toBe("first");
+    expect(history[1].proposal.rationale).toBe("second");
+  });
+
+  it("failed apply does not add to history", () => {
+    const cp = new ChangeProtocol(seedGraph());
+    const p = cp.proposeAddNode({ id: "a", type: "concept" }, "fail");
+    cp.apply(p);
+
+    expect(cp.getHistory()).toHaveLength(0);
+  });
+
+  it("snapshots grow with each apply", () => {
+    const cp = new ChangeProtocol(seedGraph());
+    expect(cp.getSnapshots()).toHaveLength(1);
+
+    cp.apply(cp.proposeAddNode({ id: "c", type: "spec", label: "C" }, "one"));
+    expect(cp.getSnapshots()).toHaveLength(2);
+
+    cp.apply(cp.proposeAddNode({ id: "d", type: "spec", label: "D" }, "two"));
+    expect(cp.getSnapshots()).toHaveLength(3);
+  });
+
+  it("history diff captures added node", () => {
+    const cp = new ChangeProtocol(seedGraph());
+    const p = cp.proposeAddNode({ id: "c", type: "spec", label: "C" }, "add");
+    const result = cp.apply(p);
+
+    expect(result.diff.summary.nodesAdded).toBe(1);
+    expect(result.diff.nodes.added[0].id).toBe("c");
+  });
+
+  it("getStats reflects current state", () => {
+    const cp = new ChangeProtocol(seedGraph());
+    cp.apply(cp.proposeAddNode({ id: "c", type: "spec", label: "C" }, "one"));
+
+    const stats = cp.getStats();
+    expect(stats.nodeCount).toBe(3);
+    expect(stats.edgeCount).toBe(1);
+    expect(stats.historyLength).toBe(1);
+    expect(stats.snapshotCount).toBe(2);
+  });
+
+  it("exportHistory returns structured data", () => {
+    const cp = new ChangeProtocol(seedGraph());
+    cp.apply(cp.proposeAddNode({ id: "c", type: "spec", label: "C" }, "add C"));
+
+    const exported = cp.exportHistory();
+    expect(exported.graph.nodes).toHaveLength(3);
+    expect(exported.history).toHaveLength(1);
+    expect(exported.history[0].type).toBe(MUTATION_TYPE.ADD_NODE);
+    expect(exported.history[0].rationale).toBe("add C");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ChangeProtocol — STRICTNESS.MINIMAL is used
+// ---------------------------------------------------------------------------
+
+describe("ChangeProtocol — strictness level", () => {
+  it("validates at MINIMAL strictness (G1, G2, G3, I1, I2)", () => {
+    const cp = new ChangeProtocol(seedGraph());
+    const p = cp.proposeAddNode(
+      { id: "c", type: "spec", label: "Gamma" },
+      "test strictness",
+    );
+
+    const validation = cp.validate(p);
+    expect(validation.valid).toBe(true);
+    expect(validation.invariantResult.total).toBe(5);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ChangeProtocol — author types
+// ---------------------------------------------------------------------------
+
+describe("ChangeProtocol — author types", () => {
+  it("accepts LLM author", () => {
+    const cp = new ChangeProtocol(seedGraph());
+    const p = cp.proposeAddNode(
+      { id: "c", type: "spec", label: "LLM node" },
+      "llm proposed",
+      AUTHOR_TYPE.LLM,
+    );
+    expect(p.author).toBe(AUTHOR_TYPE.LLM);
+
+    const result = cp.apply(p);
+    expect(result.success).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ChangeProtocol — getGraph returns copy
+// ---------------------------------------------------------------------------
+
+describe("ChangeProtocol — isolation", () => {
+  it("getGraph returns a copy (not a reference)", () => {
+    const cp = new ChangeProtocol(seedGraph());
+    const g1 = cp.getGraph();
+    g1.nodes.push({ id: "injected" });
+
+    const g2 = cp.getGraph();
+    expect(g2.nodes).toHaveLength(2);
+  });
+});

--- a/src/core/__tests__/StructuralInvariants.test.js
+++ b/src/core/__tests__/StructuralInvariants.test.js
@@ -1,0 +1,543 @@
+import { describe, it, expect } from "vitest";
+import {
+  checkUniqueNodeIds,
+  checkUniqueEdgeIds,
+  checkNoDanglingEdges,
+  checkNoSelfLoops,
+  checkAllNodesHaveId,
+  checkAllNodesHaveType,
+  checkKnownNodeTypes,
+  checkAllNodesHaveLabel,
+  checkAllEdgesHaveType,
+  checkKnownEdgeTypes,
+  checkNoDuplicateEdges,
+  checkGraphConnected,
+  checkNoIsolatedNodes,
+  checkHasRootNode,
+  checkNoContainsCycles,
+  checkSingleParent,
+  InvariantChecker,
+  STRICTNESS,
+} from "../StructuralInvariants.js";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function validGraph() {
+  return {
+    nodes: [
+      { id: "a", type: "concept", label: "Alpha" },
+      { id: "b", type: "concept", label: "Beta" },
+      { id: "c", type: "spec", label: "Gamma" },
+    ],
+    edges: [
+      { id: "e1", source: "a", target: "b", type: "defines" },
+      { id: "e2", source: "b", target: "c", type: "implements" },
+    ],
+  };
+}
+
+function emptyGraph() {
+  return { nodes: [], edges: [] };
+}
+
+// ---------------------------------------------------------------------------
+// INV-G1: Unique Node IDs
+// ---------------------------------------------------------------------------
+
+describe("INV-G1: Unique Node IDs", () => {
+  it("holds on valid graph", () => {
+    const result = checkUniqueNodeIds(validGraph());
+    expect(result.holds).toBe(true);
+    expect(result.violations).toHaveLength(0);
+  });
+
+  it("holds on empty graph", () => {
+    const result = checkUniqueNodeIds(emptyGraph());
+    expect(result.holds).toBe(true);
+  });
+
+  it("detects duplicate node IDs", () => {
+    const graph = {
+      nodes: [
+        { id: "a", type: "concept", label: "Alpha" },
+        { id: "a", type: "spec", label: "Alpha copy" },
+        { id: "b", type: "concept", label: "Beta" },
+      ],
+      edges: [],
+    };
+    const result = checkUniqueNodeIds(graph);
+    expect(result.holds).toBe(false);
+    expect(result.violations).toHaveLength(1);
+    expect(result.violations[0].type).toBe("duplicate_id");
+    expect(result.violations[0].id).toBe("a");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// INV-G2: Unique Edge IDs
+// ---------------------------------------------------------------------------
+
+describe("INV-G2: Unique Edge IDs", () => {
+  it("holds on valid graph", () => {
+    const result = checkUniqueEdgeIds(validGraph());
+    expect(result.holds).toBe(true);
+    expect(result.violations).toHaveLength(0);
+  });
+
+  it("detects duplicate edge IDs", () => {
+    const graph = {
+      nodes: [{ id: "a" }, { id: "b" }],
+      edges: [
+        { id: "e1", source: "a", target: "b", type: "defines" },
+        { id: "e1", source: "b", target: "a", type: "implements" },
+      ],
+    };
+    const result = checkUniqueEdgeIds(graph);
+    expect(result.holds).toBe(false);
+    expect(result.violations[0].type).toBe("duplicate_id");
+  });
+
+  it("detects missing edge ID", () => {
+    const graph = {
+      nodes: [{ id: "a" }, { id: "b" }],
+      edges: [{ source: "a", target: "b", type: "defines" }],
+    };
+    const result = checkUniqueEdgeIds(graph);
+    expect(result.holds).toBe(false);
+    expect(result.violations[0].type).toBe("missing_id");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// INV-G3: No Dangling Edges
+// ---------------------------------------------------------------------------
+
+describe("INV-G3: No Dangling Edges", () => {
+  it("holds on valid graph", () => {
+    const result = checkNoDanglingEdges(validGraph());
+    expect(result.holds).toBe(true);
+  });
+
+  it("detects dangling source", () => {
+    const graph = {
+      nodes: [{ id: "b" }],
+      edges: [{ id: "e1", source: "missing", target: "b", type: "defines" }],
+    };
+    const result = checkNoDanglingEdges(graph);
+    expect(result.holds).toBe(false);
+    expect(result.violations.some(v => v.type === "dangling_source")).toBe(true);
+  });
+
+  it("detects dangling target", () => {
+    const graph = {
+      nodes: [{ id: "a" }],
+      edges: [{ id: "e1", source: "a", target: "missing", type: "defines" }],
+    };
+    const result = checkNoDanglingEdges(graph);
+    expect(result.holds).toBe(false);
+    expect(result.violations.some(v => v.type === "dangling_target")).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// INV-G4: No Self-Loops
+// ---------------------------------------------------------------------------
+
+describe("INV-G4: No Self-Loops", () => {
+  it("holds on valid graph", () => {
+    const result = checkNoSelfLoops(validGraph());
+    expect(result.holds).toBe(true);
+  });
+
+  it("detects self-loop", () => {
+    const graph = {
+      nodes: [{ id: "a" }],
+      edges: [{ id: "e1", source: "a", target: "a", type: "defines" }],
+    };
+    const result = checkNoSelfLoops(graph);
+    expect(result.holds).toBe(false);
+    expect(result.violations[0].type).toBe("self_loop");
+    expect(result.violations[0].nodeId).toBe("a");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// INV-I1: All Nodes Have ID
+// ---------------------------------------------------------------------------
+
+describe("INV-I1: All Nodes Have ID", () => {
+  it("holds on valid graph", () => {
+    const result = checkAllNodesHaveId(validGraph());
+    expect(result.holds).toBe(true);
+  });
+
+  it("detects missing id", () => {
+    const graph = { nodes: [{ type: "concept", label: "No ID" }], edges: [] };
+    const result = checkAllNodesHaveId(graph);
+    expect(result.holds).toBe(false);
+    expect(result.violations[0].type).toBe("missing_id");
+  });
+
+  it("detects empty string id", () => {
+    const graph = { nodes: [{ id: "  ", type: "concept" }], edges: [] };
+    const result = checkAllNodesHaveId(graph);
+    expect(result.holds).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// INV-I2: All Nodes Have Type
+// ---------------------------------------------------------------------------
+
+describe("INV-I2: All Nodes Have Type", () => {
+  it("holds on valid graph", () => {
+    const result = checkAllNodesHaveType(validGraph());
+    expect(result.holds).toBe(true);
+  });
+
+  it("detects missing type", () => {
+    const graph = { nodes: [{ id: "a", label: "Alpha" }], edges: [] };
+    const result = checkAllNodesHaveType(graph);
+    expect(result.holds).toBe(false);
+    expect(result.violations[0].type).toBe("missing_type");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// INV-I3: Known Node Types
+// ---------------------------------------------------------------------------
+
+describe("INV-I3: Known Node Types", () => {
+  // NODE_TYPES is empty {} by design — worlds override via WorldAdapter.
+  // With empty NODE_TYPES, every typed node is "unknown".
+  it("flags all types as unknown when NODE_TYPES is empty", () => {
+    const result = checkKnownNodeTypes(validGraph());
+    expect(result.holds).toBe(false);
+    expect(result.violations.length).toBe(3);
+    expect(result.violations.every(v => v.type === "unknown_type")).toBe(true);
+  });
+
+  it("holds on empty graph (vacuously)", () => {
+    const result = checkKnownNodeTypes(emptyGraph());
+    expect(result.holds).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// INV-I4: All Nodes Have Label
+// ---------------------------------------------------------------------------
+
+describe("INV-I4: All Nodes Have Label", () => {
+  it("holds on valid graph", () => {
+    const result = checkAllNodesHaveLabel(validGraph());
+    expect(result.holds).toBe(true);
+  });
+
+  it("detects missing label", () => {
+    const graph = { nodes: [{ id: "a", type: "concept" }], edges: [] };
+    const result = checkAllNodesHaveLabel(graph);
+    expect(result.holds).toBe(false);
+    expect(result.violations[0].type).toBe("missing_label");
+  });
+
+  it("detects empty string label", () => {
+    const graph = { nodes: [{ id: "a", type: "concept", label: "  " }], edges: [] };
+    const result = checkAllNodesHaveLabel(graph);
+    expect(result.holds).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// INV-E1: All Edges Have Type
+// ---------------------------------------------------------------------------
+
+describe("INV-E1: All Edges Have Type", () => {
+  it("holds on valid graph", () => {
+    const result = checkAllEdgesHaveType(validGraph());
+    expect(result.holds).toBe(true);
+  });
+
+  it("detects missing edge type", () => {
+    const graph = {
+      nodes: [{ id: "a" }, { id: "b" }],
+      edges: [{ id: "e1", source: "a", target: "b" }],
+    };
+    const result = checkAllEdgesHaveType(graph);
+    expect(result.holds).toBe(false);
+    expect(result.violations[0].type).toBe("missing_type");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// INV-E2: Known Edge Types
+// ---------------------------------------------------------------------------
+
+describe("INV-E2: Known Edge Types", () => {
+  // EDGE_TYPES is empty {} by design — same as INV-I3.
+  it("flags all types as unknown when EDGE_TYPES is empty", () => {
+    const result = checkKnownEdgeTypes(validGraph());
+    expect(result.holds).toBe(false);
+    expect(result.violations.every(v => v.type === "unknown_type")).toBe(true);
+  });
+
+  it("holds on empty graph (vacuously)", () => {
+    const result = checkKnownEdgeTypes(emptyGraph());
+    expect(result.holds).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// INV-E3: No Duplicate Edges
+// ---------------------------------------------------------------------------
+
+describe("INV-E3: No Duplicate Edges", () => {
+  it("holds on valid graph", () => {
+    const result = checkNoDuplicateEdges(validGraph());
+    expect(result.holds).toBe(true);
+  });
+
+  it("detects duplicate edge (same source, target, type)", () => {
+    const graph = {
+      nodes: [{ id: "a" }, { id: "b" }],
+      edges: [
+        { id: "e1", source: "a", target: "b", type: "defines" },
+        { id: "e2", source: "a", target: "b", type: "defines" },
+      ],
+    };
+    const result = checkNoDuplicateEdges(graph);
+    expect(result.holds).toBe(false);
+    expect(result.violations[0].type).toBe("duplicate_edge");
+  });
+
+  it("allows same endpoints with different types", () => {
+    const graph = {
+      nodes: [{ id: "a" }, { id: "b" }],
+      edges: [
+        { id: "e1", source: "a", target: "b", type: "defines" },
+        { id: "e2", source: "a", target: "b", type: "implements" },
+      ],
+    };
+    const result = checkNoDuplicateEdges(graph);
+    expect(result.holds).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// INV-C1: Graph Connected
+// ---------------------------------------------------------------------------
+
+describe("INV-C1: Graph Connected", () => {
+  it("holds on connected graph", () => {
+    const result = checkGraphConnected(validGraph());
+    expect(result.holds).toBe(true);
+  });
+
+  it("holds on empty graph (trivially)", () => {
+    const result = checkGraphConnected(emptyGraph());
+    expect(result.holds).toBe(true);
+  });
+
+  it("detects disconnected graph", () => {
+    const graph = {
+      nodes: [
+        { id: "a", type: "concept" },
+        { id: "b", type: "concept" },
+        { id: "c", type: "concept" },
+      ],
+      edges: [{ id: "e1", source: "a", target: "b", type: "defines" }],
+    };
+    const result = checkGraphConnected(graph);
+    expect(result.holds).toBe(false);
+    expect(result.violations.some(v => v.nodeId === "c")).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// INV-C2: No Isolated Nodes
+// ---------------------------------------------------------------------------
+
+describe("INV-C2: No Isolated Nodes", () => {
+  it("holds on valid graph (all nodes have edges)", () => {
+    const result = checkNoIsolatedNodes(validGraph());
+    expect(result.holds).toBe(true);
+  });
+
+  it("detects isolated node", () => {
+    const graph = {
+      nodes: [
+        { id: "a", type: "concept" },
+        { id: "b", type: "concept" },
+        { id: "lonely", type: "concept", label: "Lonely" },
+      ],
+      edges: [{ id: "e1", source: "a", target: "b", type: "defines" }],
+    };
+    const result = checkNoIsolatedNodes(graph);
+    expect(result.holds).toBe(false);
+    expect(result.violations[0].nodeId).toBe("lonely");
+    expect(result.violations[0].type).toBe("isolated");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// INV-C3: Has Root Node
+// ---------------------------------------------------------------------------
+
+describe("INV-C3: Has Root Node", () => {
+  // NODE_TYPES.ROOT is undefined (empty NODE_TYPES), so no node can match.
+  it("always fails with empty NODE_TYPES (no type matches undefined)", () => {
+    const result = checkHasRootNode(validGraph());
+    expect(result.holds).toBe(false);
+  });
+
+  it("holds when a node has type matching NODE_TYPES.ROOT", () => {
+    // Manually simulate what would happen if NODE_TYPES.ROOT were defined:
+    // Since NODE_TYPES is empty, NODE_TYPES.ROOT === undefined,
+    // so n.type === undefined matches nodes without a type field.
+    const graph = {
+      nodes: [{ id: "root" }],
+      edges: [],
+    };
+    const result = checkHasRootNode(graph);
+    expect(result.holds).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// INV-H1: No Contains Cycles
+// ---------------------------------------------------------------------------
+
+describe("INV-H1: No Contains Cycles", () => {
+  // EDGE_TYPES.CONTAINS is undefined, so no edge matches the filter.
+  it("holds vacuously when no edges match EDGE_TYPES.CONTAINS", () => {
+    const result = checkNoContainsCycles(validGraph());
+    expect(result.holds).toBe(true);
+  });
+
+  it("detects cycle in contains hierarchy with matching edge type", () => {
+    // Since EDGE_TYPES.CONTAINS is undefined, edges with type=undefined match.
+    const graph = {
+      nodes: [{ id: "a" }, { id: "b" }, { id: "c" }],
+      edges: [
+        { id: "e1", source: "a", target: "b" },
+        { id: "e2", source: "b", target: "c" },
+        { id: "e3", source: "c", target: "a" },
+      ],
+    };
+    const result = checkNoContainsCycles(graph);
+    expect(result.holds).toBe(false);
+    expect(result.violations.length).toBeGreaterThan(0);
+    expect(result.violations[0].type).toBe("cycle");
+  });
+
+  it("holds on acyclic contains hierarchy", () => {
+    const graph = {
+      nodes: [{ id: "a" }, { id: "b" }, { id: "c" }],
+      edges: [
+        { id: "e1", source: "a", target: "b" },
+        { id: "e2", source: "a", target: "c" },
+      ],
+    };
+    const result = checkNoContainsCycles(graph);
+    expect(result.holds).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// INV-H2: Single Parent in Contains
+// ---------------------------------------------------------------------------
+
+describe("INV-H2: Single Parent in Contains", () => {
+  it("holds vacuously when no edges match EDGE_TYPES.CONTAINS", () => {
+    const result = checkSingleParent(validGraph());
+    expect(result.holds).toBe(true);
+  });
+
+  it("detects multiple parents in contains hierarchy", () => {
+    // edges without type → type === undefined === EDGE_TYPES.CONTAINS
+    const graph = {
+      nodes: [{ id: "a" }, { id: "b" }, { id: "child" }],
+      edges: [
+        { id: "e1", source: "a", target: "child" },
+        { id: "e2", source: "b", target: "child" },
+      ],
+    };
+    const result = checkSingleParent(graph);
+    expect(result.holds).toBe(false);
+    expect(result.violations[0].type).toBe("multiple_parents");
+    expect(result.violations[0].nodeId).toBe("child");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// InvariantChecker — aggregated checking
+// ---------------------------------------------------------------------------
+
+describe("InvariantChecker", () => {
+  it("MINIMAL strictness checks G1, G2, G3, I1, I2 (5 checks)", () => {
+    const checker = new InvariantChecker();
+    const result = checker.checkAll(validGraph(), STRICTNESS.MINIMAL);
+    expect(result.total).toBe(5);
+    expect(result.valid).toBe(true);
+    expect(result.passed).toBe(5);
+    expect(result.failed).toBe(0);
+  });
+
+  it("STANDARD strictness adds E1, C2, G4 (8 checks total)", () => {
+    const checker = new InvariantChecker();
+    const result = checker.checkAll(validGraph(), STRICTNESS.STANDARD);
+    expect(result.total).toBe(8);
+    expect(result.valid).toBe(true);
+  });
+
+  it("STRICT strictness runs all 16 checks", () => {
+    const checker = new InvariantChecker();
+    const result = checker.checkAll(validGraph(), STRICTNESS.STRICT);
+    expect(result.total).toBe(16);
+    // Some fail due to empty NODE_TYPES/EDGE_TYPES (I3, E2 always fail; C3 fails)
+    expect(result.failed).toBeGreaterThan(0);
+    expect(result.violations.length).toBeGreaterThan(0);
+  });
+
+  it("reports violations on graph with errors", () => {
+    const broken = {
+      nodes: [
+        { id: "a", type: "concept" },
+        { id: "a", type: "spec" },
+      ],
+      edges: [{ source: "a", target: "missing", type: "defines" }],
+    };
+    const checker = new InvariantChecker();
+    const result = checker.checkAll(broken, STRICTNESS.MINIMAL);
+    expect(result.valid).toBe(false);
+    expect(result.violations.length).toBeGreaterThan(0);
+  });
+
+  it("checkOne returns result for known invariant", () => {
+    const checker = new InvariantChecker();
+    const result = checker.checkOne("INV-G1", validGraph());
+    expect(result).not.toBeNull();
+    expect(result.holds).toBe(true);
+  });
+
+  it("checkOne returns null for unknown invariant", () => {
+    const checker = new InvariantChecker();
+    const result = checker.checkOne("INV-FAKE", validGraph());
+    expect(result).toBeNull();
+  });
+
+  it("listInvariants returns 16 entries", () => {
+    const list = InvariantChecker.listInvariants();
+    expect(list).toHaveLength(16);
+    expect(list.every(i => i.id && i.name && i.category)).toBe(true);
+  });
+
+  it("reset clears previous results", () => {
+    const checker = new InvariantChecker();
+    checker.checkAll(validGraph(), STRICTNESS.MINIMAL);
+    expect(checker.results.length).toBe(5);
+    checker.reset();
+    expect(checker.results.length).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Add 48 dedicated tests for `StructuralInvariants.js` covering all 16 checker functions across 5 categories
- Add 36 dedicated tests for `ChangeProtocol.js` covering happy path, rejection, simulate, history, strictness
- Fix 4 bugs in `ProposalValidator` discovered during testing
- Update evidence docs: 19 invariants upgraded from intended/partial to evidenced (40/44 total)

Closes #9

## Bugs found and fixed
1. **Static method on instance:** `this.schemaValidator.validateNode()` - static method called on instance throws TypeError. Fixed: `SchemaValidator.validateNode()`  
2. **Count vs boolean:** `!invariantResult.passed` checks count, not validity. Fixed: `!invariantResult.valid`  
3. **Number vs array:** `for (of invariantResult.failed)` - failed is a number. Fixed: `invariantResult.violations`  
4. **Wrong property:** `failure.error` - InvariantResult has message. Fixed: `failure.message`  

## Non-goals
- No general core test overhaul
- No architecture rewrites
- No public promise changes

## Acceptance checklist
- [x] Dedicated tests exist for StructuralInvariants.js (48 tests)
- [x] Dedicated tests exist for ChangeProtocol.js (36 tests)
- [x] Implementation fixes are minimal and tied to failing tests
- [x] Evidence docs updated accordingly
- [x] All tests pass (755/755)
- [x] No unrelated runtime/API changes

## Files changed
- `src/core/__tests__/StructuralInvariants.test.js` (new - 48 tests)
- `src/core/__tests__/ChangeProtocol.test.js` (new - 36 tests)
- `src/core/ChangeProtocol.js` (4 bug fixes)
- `docs/INVARIANT_MATRIX.md` (19 status upgrades)
- `docs/PROOF_OBLIGATIONS.md` (2 gaps closed)

## Evidence gaps addressed from B1
- Gap #1 (StructuralInvariants): CLOSED - 16 invariants now evidenced
- Gap #2 (ChangeProtocol): CLOSED - 3 invariants now evidenced

Made with [Cursor](https://cursor.com)