### PR TITLE
B3: Projection metadata, GraphSnapshot, and KE5 edge-case evidence

### DIFF
--- a/docs/INVARIANT_MATRIX.md
+++ b/docs/INVARIANT_MATRIX.md
@@ -23,11 +23,11 @@ Defined in: [README.md](../README.md), [EPISTEMIC_LOG.md](../EPISTEMIC_LOG.md), 
 | KE2 | Reject never mutates the graph | Test suite | `knowledgeInvariants.test.js` — "KE2: reject does not affect the graph"; `verificationWorkflow.test.js` — VW4; `reviewWorkflow.test.js` — RW4, RW5; `endToEnd.test.js` | **evidenced** |
 | KE3 | Every graph change traces to an epistemic event | Test suite + architecture | `knowledgeInvariants.test.js` — "KE3: approve deterministically adds to the graph"; `reviewWorkflow.test.js` — RW3, RW6; `verificationWorkflow.test.js` — VW3; `endToEnd.test.js` — "incremental log"; pipeline enforced by `evaluate()` → `getCanonicalStatements()` → `buildGraphFromStatements()` | **evidenced** |
 | KE4 | Evaluate is idempotent | Test suite | `knowledgeInvariants.test.js` — "KE4: repeated evaluate(log) is stable"; `evaluate.test.js` — "approve on already canonical → idempotent", "determinism: same log evaluated twice → identical result" | **evidenced** |
-| KE5 | Graph rebuild preserves ViewModel stability | Test suite (partial) | `knowledgeInvariants.test.js` — "KE5: projection remains total after any valid event sequence", edge case test; `verificationWorkflow.test.js` — VW11; `reviewWorkflow.test.js` — RW7; `buildGraph.test.js` — "graph from statements passes projectGraph"; `endToEnd.test.js` — full cycle | **partially evidenced** |
+| KE5 | Graph rebuild preserves ViewModel stability | Test suite | `knowledgeInvariants.test.js` — "KE5: projection remains total after any valid event sequence", "KE5 (edge case): empty canonical set → projection on empty graph returns ok:false"; `verificationWorkflow.test.js` — VW11; `reviewWorkflow.test.js` — RW7; `buildGraph.test.js` — "graph from statements passes projectGraph"; `endToEnd.test.js` — full cycle | **evidenced** |
 
-### KE5 evidence gap
+### KE5 edge case — closed in B3
 
-The KE5 edge case test ("empty canonical set → projection on empty graph still total") asserts that `buildGraphFromStatements([])` yields an empty graph but does not call `projectGraph` on it. Meanwhile, `validateInputs.js` rejects empty graphs (`"graph has no nodes"`), so `projectGraph` on an empty graph returns `{ ok: false }`. The invariant holds for non-empty graphs; the edge case boundary is documented but not fully tested.
+The KE5 edge case test now calls `projectGraph` on an empty graph and asserts `{ ok: false, errors: ['graph has no nodes'] }`. This confirms that `validateInputs.js` rejects empty graphs as designed, and the totality property (INV-7) holds: the pipeline always returns either a valid ViewModel or a typed error. The boundary is now documented and tested.
 
 ---
 
@@ -55,13 +55,13 @@ Defined in: [README.md](../README.md), [ARCHITECTURE.md](../ARCHITECTURE.md), `p
 |----|-----------|---------------|-----------------|--------|
 | INV-3 | Projection determinism: same `(graph, focus, params)` → same ViewModel | Test suite | `projectGraph.test.js` — "INV-3: Projection Determinism" (no focus, alice, root/depth 2, 100 repeated calls); `domainProjection.test.js` — Theorem 7; `workbenchProjection.test.js` — Theorem 4; `characterContext.test.js` — Theorem 8 | **evidenced** |
 | INV-7 | Projection totality: always returns ViewModel or typed error | Test suite | `projectGraph.test.js` — "INV-7: Projection Totality" (ok for valid input; ok:false for null graph, nonexistent focus, negative depth) | **evidenced** |
-| INV-1 | Schema conformance | Metadata only | `buildViewModel.js` — listed in `satisfiedInvariants`; no dedicated test | **intended** |
-| INV-2 | Identity stability | Metadata only | `buildViewModel.js` — listed in `satisfiedInvariants`; no dedicated test | **intended** |
-| INV-4 | Graph immutability (projection does not mutate input) | Architecture | `buildViewModel.js` — listed in `satisfiedInvariants`; enforced by pure-function design of all 5 pipeline steps; no dedicated mutation test | **intended** |
+| INV-1 | Schema conformance | Test suite | `projectionMetadata.test.js` — "INV-1: Schema Conformance" (15 tests): ViewModel top-level keys, VisualNode fields (id/label/type/role/opacity/metadata), VisualEdge fields (id/source/target/type/opacity/touchesFocus), panels structure, breadcrumbs, navigation, meta, system, satisfiedInvariants content, transitions | **evidenced** |
+| INV-2 | Identity stability | Test suite | `projectionMetadata.test.js` — "INV-2: Identity Stability" (9 tests): all source node IDs appear in ViewModel, IDs preserved exactly, edge source/target reference valid IDs, focused node ID matches input, identity stable across repeated projections, visible IDs subset of graph IDs, edge IDs preserved, breadcrumbs/path IDs match | **evidenced** |
+| INV-4 | Graph immutability (projection does not mutate input) | Test suite | `projectionMetadata.test.js` — "INV-4: Graph Immutability" (7 tests): node/edge count unchanged, node/edge properties unchanged (deep comparison), graph unchanged after multiple projections with different foci, graph unchanged on error path, getNodeById still works after projection | **evidenced** |
 
-### PROJ purity note
+### PROJ evidence note — updated in B3
 
-The projection pipeline (`validateInputs → resolveFocus → computeVisibleSubgraph → deriveSemanticRoles → buildViewModel`) is implemented as a chain of pure, synchronous functions with no external I/O or shared state. Each step documents "no side effects" in its JSDoc header. INV-3 (determinism) and INV-7 (totality) are the formalized, tested projections of the PROJ invariant. INV-1, INV-2, INV-4 are declared in metadata but lack standalone tests.
+All 5 PROJ invariants now have dedicated tests. The projection pipeline (`validateInputs → resolveFocus → computeVisibleSubgraph → deriveSemanticRoles → buildViewModel`) is a chain of pure, synchronous functions with no external I/O or shared state. INV-3 (determinism) and INV-7 (totality) were proven in the original test suite. INV-1, INV-2, and INV-4 are now proven by `projectionMetadata.test.js` (32 tests).
 
 ---
 
@@ -173,11 +173,11 @@ Four bugs were discovered in `ProposalValidator` during test development:
 
 | Family | Count | Evidenced | Partially evidenced | Intended |
 |--------|-------|-----------|---------------------|----------|
-| KE | 5 | 4 | 1 (KE5) | 0 |
+| KE | 5 | 5 | 0 | 0 |
 | NAV | 5 | 5 | 0 | 0 |
-| PROJ | 5 | 2 (INV-3, INV-7) | 0 | 3 (INV-1, INV-2, INV-4) |
+| PROJ | 5 | 5 | 0 | 0 |
 | Structural | 16 | 16 | 0 | 0 |
 | OP | 3 | 3 | 0 | 0 |
 | ENG | 7 | 7 | 0 | 0 |
 | CP | 3 | 3 | 0 | 0 |
-| **Total** | **44** | **40** | **1** | **3** |
+| **Total** | **44** | **44** | **0** | **0** |

--- a/docs/PROOF_OBLIGATIONS.md
+++ b/docs/PROOF_OBLIGATIONS.md
@@ -37,7 +37,7 @@ The epistemic pipeline (`propose → verify → approve/reject → evaluate → 
 | Reject safety (KE2) | 5 tests across 3 test files | High |
 | Event causality (KE3) | 5 tests across 3 test files | High |
 | Idempotent evaluation (KE4) | 3 tests across 2 test files | High |
-| ViewModel stability after rebuild (KE5) | 6 tests; edge case gap noted | Medium-high |
+| ViewModel stability after rebuild (KE5) | 7 tests; edge case closed in B3 | High |
 
 Evidence basis: `src/core/knowledge/__tests__/knowledgeInvariants.test.js` contains dedicated KE1–KE5 tests. Additional coverage in `evaluate.test.js`, `buildGraph.test.js`, `reviewWorkflow.test.js`, `verificationWorkflow.test.js`, `endToEnd.test.js`.
 
@@ -53,18 +53,18 @@ Evidence basis: `src/core/knowledge/__tests__/knowledgeInvariants.test.js` conta
 
 Evidence basis: `src/core/navigation/__tests__/applyTransition.test.js` — dedicated NAV-1 through NAV-5 describe blocks.
 
-### 2.3 Projection — strong evidence (core), partial (metadata invariants)
+### 2.3 Projection — strong evidence
 
 | Property | Tests | Confidence |
 |----------|-------|------------|
 | Determinism (INV-3) | 4+ tests across 4 test files (incl. 100-call loop) | High |
 | Totality (INV-7) | 4 test cases (valid + 3 error paths) | High |
 | 5-step pipeline correctness | Step-by-step tests in `projectGraph.test.js` | High |
-| Schema conformance (INV-1) | No dedicated test | Low |
-| Identity stability (INV-2) | No dedicated test | Low |
-| Graph immutability (INV-4) | Enforced by design (pure functions), not by test | Low |
+| Schema conformance (INV-1) | 15 tests in `projectionMetadata.test.js` | High |
+| Identity stability (INV-2) | 9 tests in `projectionMetadata.test.js` | High |
+| Graph immutability (INV-4) | 7 tests in `projectionMetadata.test.js` | High |
 
-Evidence basis: `src/core/projection/__tests__/projectGraph.test.js` plus domain/workbench/character context test files.
+Evidence basis: `src/core/projection/__tests__/projectGraph.test.js`, `projectionMetadata.test.js`, plus domain/workbench/character context test files.
 
 ### 2.4 Operators — strong evidence
 
@@ -99,15 +99,13 @@ All 16 checkers now have dedicated tests (48 tests in `StructuralInvariants.test
 
 Full pipeline tested (36 tests in `ChangeProtocol.test.js`): happy path, rejection, simulate, history, strictness. Four bugs discovered and fixed in `ProposalValidator` (see INVARIANT_MATRIX.md for details). Status upgraded to **evidenced**.
 
-### 3.3 Projection metadata invariants (INV-1, INV-2, INV-4)
+### ~~3.3 Projection metadata invariants (INV-1, INV-2, INV-4)~~ — CLOSED in B3
 
-`buildViewModel.js` declares these in its `satisfiedInvariants` metadata field, but they have no standalone tests:
+All three projection metadata invariants now have dedicated tests (32 tests in `projectionMetadata.test.js`):
 
-- **INV-1 (Schema conformance):** ViewModel output conforms to a declared schema — no schema test
-- **INV-2 (Identity stability):** Node identities are preserved through projection — no identity test
-- **INV-4 (Graph immutability):** Projection does not mutate its input graph — no mutation test
-
-These properties are enforced by design (pure functions, no mutation), but a defensive test would catch regressions.
+- **INV-1 (Schema conformance):** 15 tests verify ViewModel structure: top-level keys, VisualNode/VisualEdge fields and types, panels/navigation/meta/system structure, `satisfiedInvariants` content, and `transitions`.
+- **INV-2 (Identity stability):** 9 tests verify ID preservation: all source IDs appear in output, IDs not transformed, edge references valid, focused node matches input, stability across repeated projections, breadcrumb/path IDs match.
+- **INV-4 (Graph immutability):** 7 tests verify input graph is unchanged: node/edge counts, deep property comparison, immutability after multiple projections with different foci, immutability on error path.
 
 ### 3.4 Highlight model
 
@@ -137,21 +135,21 @@ Listed in priority order based on risk and coverage impact.
 
 Gaps #1 (StructuralInvariants) and #2 (ChangeProtocol) are now closed with dedicated test suites. See B2 PR for details.
 
-### Important (remaining)
+### ~~Important~~ — CLOSED in B3
 
-| # | Gap | Suggested artifact | Impact |
-|---|-----|--------------------|--------|
-| 1 | GraphSnapshot immutability not tested | Test that `Object.freeze` is applied and mutation attempts throw | Snapshot integrity |
-| 2 | KE5 edge case: empty graph projection | Add assertion in `knowledgeInvariants.test.js` KE5 edge case that actually calls `projectGraph` on empty graph and checks `ok: false` | KE5 fully locked |
-| 3 | INV-4 (graph immutability through projection) | Test that `projectGraph` input graph is unchanged after call | PROJ immutability proven |
-| 4 | INV-1/INV-2 (schema conformance, identity stability) | Define and test ViewModel schema contract | PROJ metadata invariants promoted from intended to evidenced |
+Gaps #1–#4 are now closed:
+
+- **#1 GraphSnapshot immutability:** 62 tests in `GraphSnapshot.test.js` cover creation, `Object.freeze` behavior (snapshot/nodes/edges/metadata all frozen, mutation attempts throw), accessors, statistics, serialization round-trip, `diffSnapshots`, and `SnapshotHistory`.
+- **#2 KE5 edge case:** Updated test now calls `projectGraph` on empty graph and asserts `{ ok: false, errors: ['graph has no nodes'] }`.
+- **#3 INV-4 (graph immutability):** 7 tests in `projectionMetadata.test.js` verify input graph unchanged after projection.
+- **#4 INV-1/INV-2:** 24 tests in `projectionMetadata.test.js` verify ViewModel schema and identity preservation.
 
 ### Desirable (documentation gaps)
 
 | # | Gap | Suggested artifact | Impact |
 |---|-----|--------------------|--------|
-| 5 | Highlight model has no tests | `src/highlight/__tests__/highlightModel.test.js` | Public API coverage |
-| 6 | Cabin diagnostic pipeline evidence | Currently tracked separately in CABIN_CLAIM_POLICY.md — no overlap with this document | Experimental module |
+| 1 | Highlight model has no tests | `src/highlight/__tests__/highlightModel.test.js` | Public API coverage |
+| 2 | Cabin diagnostic pipeline evidence | Currently tracked separately in CABIN_CLAIM_POLICY.md — no overlap with this document | Experimental module |
 
 ---
 

--- a/src/core/__tests__/GraphSnapshot.test.js
+++ b/src/core/__tests__/GraphSnapshot.test.js
@@ -1,0 +1,578 @@
+/**
+ * GraphSnapshot dedicated tests.
+ *
+ * Tests prove:
+ * - Snapshot creation from graph data
+ * - Immutability via Object.freeze (documented runtime behavior)
+ * - Accessor correctness (getNodeById, getEdgeById, hasNode, etc.)
+ * - Statistics computation
+ * - Serialization round-trip (toJSON / fromJSON)
+ * - diffSnapshots correctness
+ * - SnapshotHistory management
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  GraphSnapshot,
+  SnapshotHistory,
+  diffSnapshots,
+  CHANGE_TYPE,
+  SNAPSHOT_VERSION,
+} from '../GraphSnapshot.js';
+import { SCHEMA_VERSION } from '../CanonicalGraphSchema.js';
+
+function sampleNodes() {
+  return [
+    { id: 'n1', type: 'concept', label: 'Alpha' },
+    { id: 'n2', type: 'concept', label: 'Beta' },
+    { id: 'n3', type: 'person', label: 'Charlie' },
+  ];
+}
+
+function sampleEdges() {
+  return [
+    { id: 'e1', source: 'n1', target: 'n2', type: 'relates' },
+    { id: 'e2', source: 'n2', target: 'n3', type: 'knows' },
+  ];
+}
+
+function createSample(opts = {}) {
+  return new GraphSnapshot(
+    { nodes: sampleNodes(), edges: sampleEdges() },
+    opts,
+  );
+}
+
+// ── Creation ─────────────────────────────────────────────────────────────────
+
+describe('GraphSnapshot: creation', () => {
+  it('stores nodes and edges from input', () => {
+    const snap = createSample();
+    expect(snap.nodes.length).toBe(3);
+    expect(snap.edges.length).toBe(2);
+  });
+
+  it('accepts edges via "links" key', () => {
+    const snap = new GraphSnapshot({ nodes: sampleNodes(), links: sampleEdges() });
+    expect(snap.edges.length).toBe(2);
+  });
+
+  it('assigns auto-generated id when not provided', () => {
+    const snap = createSample();
+    expect(typeof snap.id).toBe('string');
+    expect(snap.id.startsWith('snap-')).toBe(true);
+  });
+
+  it('uses provided id', () => {
+    const snap = createSample({ id: 'custom-id' });
+    expect(snap.id).toBe('custom-id');
+  });
+
+  it('stores timestamp (defaults to Date.now)', () => {
+    const before = Date.now();
+    const snap = createSample();
+    const after = Date.now();
+    expect(snap.timestamp).toBeGreaterThanOrEqual(before);
+    expect(snap.timestamp).toBeLessThanOrEqual(after);
+  });
+
+  it('uses provided timestamp', () => {
+    const snap = createSample({ timestamp: 1000 });
+    expect(snap.timestamp).toBe(1000);
+  });
+
+  it('stores schemaVersion from CanonicalGraphSchema', () => {
+    const snap = createSample();
+    expect(snap.schemaVersion).toBe(SCHEMA_VERSION);
+  });
+
+  it('stores snapshotVersion', () => {
+    const snap = createSample();
+    expect(snap.snapshotVersion).toBe(SNAPSHOT_VERSION);
+  });
+
+  it('stores metadata with description, author, tags', () => {
+    const snap = createSample({
+      description: 'test snap',
+      author: 'opus',
+      tags: ['v1', 'test'],
+    });
+    expect(snap.metadata.description).toBe('test snap');
+    expect(snap.metadata.author).toBe('opus');
+    expect([...snap.metadata.tags]).toEqual(['v1', 'test']);
+  });
+
+  it('defaults metadata fields when not provided', () => {
+    const snap = createSample();
+    expect(snap.metadata.description).toBe('');
+    expect(snap.metadata.author).toBe('');
+    expect([...snap.metadata.tags]).toEqual([]);
+  });
+
+  it('handles empty graph data', () => {
+    const snap = new GraphSnapshot({ nodes: [], edges: [] });
+    expect(snap.nodes.length).toBe(0);
+    expect(snap.edges.length).toBe(0);
+  });
+
+  it('handles missing nodes/edges gracefully', () => {
+    const snap = new GraphSnapshot({});
+    expect(snap.nodes.length).toBe(0);
+    expect(snap.edges.length).toBe(0);
+  });
+});
+
+// ── Immutability ─────────────────────────────────────────────────────────────
+
+describe('GraphSnapshot: immutability (Object.freeze behavior)', () => {
+  it('snapshot itself is frozen', () => {
+    const snap = createSample();
+    expect(Object.isFrozen(snap)).toBe(true);
+  });
+
+  it('nodes array is frozen', () => {
+    const snap = createSample();
+    expect(Object.isFrozen(snap.nodes)).toBe(true);
+  });
+
+  it('edges array is frozen', () => {
+    const snap = createSample();
+    expect(Object.isFrozen(snap.edges)).toBe(true);
+  });
+
+  it('each node object is frozen', () => {
+    const snap = createSample();
+    for (const node of snap.nodes) {
+      expect(Object.isFrozen(node)).toBe(true);
+    }
+  });
+
+  it('each edge object is frozen', () => {
+    const snap = createSample();
+    for (const edge of snap.edges) {
+      expect(Object.isFrozen(edge)).toBe(true);
+    }
+  });
+
+  it('metadata is frozen', () => {
+    const snap = createSample();
+    expect(Object.isFrozen(snap.metadata)).toBe(true);
+  });
+
+  it('metadata.tags array is frozen', () => {
+    const snap = createSample({ tags: ['a', 'b'] });
+    expect(Object.isFrozen(snap.metadata.tags)).toBe(true);
+  });
+
+  it('push to nodes array throws in strict mode', () => {
+    const snap = createSample();
+    expect(() => { snap.nodes.push({ id: 'x' }); }).toThrow();
+  });
+
+  it('property assignment on node throws in strict mode', () => {
+    const snap = createSample();
+    expect(() => { snap.nodes[0].label = 'mutated'; }).toThrow();
+  });
+
+  it('push to edges array throws in strict mode', () => {
+    const snap = createSample();
+    expect(() => { snap.edges.push({ id: 'x' }); }).toThrow();
+  });
+
+  it('property assignment on snapshot throws in strict mode', () => {
+    const snap = createSample();
+    expect(() => { snap.id = 'changed'; }).toThrow();
+  });
+
+  it('source data mutation does not affect snapshot', () => {
+    const nodes = sampleNodes();
+    const edges = sampleEdges();
+    const snap = new GraphSnapshot({ nodes, edges });
+
+    nodes.push({ id: 'n4', type: 'x', label: 'Extra' });
+    edges[0].type = 'mutated';
+
+    expect(snap.nodes.length).toBe(3);
+    expect(snap.edges[0].type).toBe('relates');
+  });
+});
+
+// ── Accessors ────────────────────────────────────────────────────────────────
+
+describe('GraphSnapshot: accessors', () => {
+  it('getNodeById returns correct node', () => {
+    const snap = createSample();
+    const node = snap.getNodeById('n2');
+    expect(node).toBeDefined();
+    expect(node.label).toBe('Beta');
+  });
+
+  it('getNodeById returns undefined for missing ID', () => {
+    const snap = createSample();
+    expect(snap.getNodeById('nonexistent')).toBeUndefined();
+  });
+
+  it('getEdgeById returns correct edge', () => {
+    const snap = createSample();
+    const edge = snap.getEdgeById('e1');
+    expect(edge).toBeDefined();
+    expect(edge.source).toBe('n1');
+    expect(edge.target).toBe('n2');
+  });
+
+  it('getEdgeById returns undefined for missing ID', () => {
+    const snap = createSample();
+    expect(snap.getEdgeById('nonexistent')).toBeUndefined();
+  });
+
+  it('getNodeIds returns Set of all node IDs', () => {
+    const snap = createSample();
+    const ids = snap.getNodeIds();
+    expect(ids instanceof Set).toBe(true);
+    expect(ids.size).toBe(3);
+    expect(ids.has('n1')).toBe(true);
+    expect(ids.has('n2')).toBe(true);
+    expect(ids.has('n3')).toBe(true);
+  });
+
+  it('getEdgeIds returns Set of all edge IDs', () => {
+    const snap = createSample();
+    const ids = snap.getEdgeIds();
+    expect(ids instanceof Set).toBe(true);
+    expect(ids.size).toBe(2);
+    expect(ids.has('e1')).toBe(true);
+    expect(ids.has('e2')).toBe(true);
+  });
+
+  it('hasNode returns true for existing, false for missing', () => {
+    const snap = createSample();
+    expect(snap.hasNode('n1')).toBe(true);
+    expect(snap.hasNode('n99')).toBe(false);
+  });
+
+  it('hasEdge returns true for existing, false for missing', () => {
+    const snap = createSample();
+    expect(snap.hasEdge('e1')).toBe(true);
+    expect(snap.hasEdge('e99')).toBe(false);
+  });
+});
+
+// ── Statistics ───────────────────────────────────────────────────────────────
+
+describe('GraphSnapshot: statistics', () => {
+  it('getStats returns correct counts', () => {
+    const snap = createSample({ id: 'stats-test', timestamp: 5000 });
+    const stats = snap.getStats();
+    expect(stats.id).toBe('stats-test');
+    expect(stats.timestamp).toBe(5000);
+    expect(stats.nodeCount).toBe(3);
+    expect(stats.edgeCount).toBe(2);
+    expect(stats.schemaVersion).toBe(SCHEMA_VERSION);
+    expect(stats.snapshotVersion).toBe(SNAPSHOT_VERSION);
+  });
+
+  it('getStats computes nodeTypes distribution', () => {
+    const snap = createSample();
+    const stats = snap.getStats();
+    expect(stats.nodeTypes.concept).toBe(2);
+    expect(stats.nodeTypes.person).toBe(1);
+  });
+
+  it('getStats computes edgeTypes distribution', () => {
+    const snap = createSample();
+    const stats = snap.getStats();
+    expect(stats.edgeTypes.relates).toBe(1);
+    expect(stats.edgeTypes.knows).toBe(1);
+  });
+
+  it('getStats handles nodes without type (uses "unknown")', () => {
+    const snap = new GraphSnapshot({
+      nodes: [{ id: 'x', label: 'X' }],
+      edges: [],
+    });
+    expect(snap.getStats().nodeTypes.unknown).toBe(1);
+  });
+});
+
+// ── Serialization ────────────────────────────────────────────────────────────
+
+describe('GraphSnapshot: serialization', () => {
+  it('toJSON produces plain object with all data', () => {
+    const snap = createSample({
+      id: 'json-test',
+      timestamp: 12345,
+      description: 'desc',
+      author: 'a',
+      tags: ['t'],
+    });
+    const json = snap.toJSON();
+    expect(json.id).toBe('json-test');
+    expect(json.timestamp).toBe(12345);
+    expect(json.nodes.length).toBe(3);
+    expect(json.edges.length).toBe(2);
+    expect(json.metadata.description).toBe('desc');
+    expect(json.metadata.author).toBe('a');
+    expect(json.metadata.tags).toEqual(['t']);
+    expect(json.schemaVersion).toBe(SCHEMA_VERSION);
+    expect(json.snapshotVersion).toBe(SNAPSHOT_VERSION);
+  });
+
+  it('toJSON returns unfrozen copies', () => {
+    const snap = createSample();
+    const json = snap.toJSON();
+    expect(Object.isFrozen(json)).toBe(false);
+    expect(Object.isFrozen(json.nodes)).toBe(false);
+    expect(Object.isFrozen(json.nodes[0])).toBe(false);
+  });
+
+  it('fromJSON round-trips correctly', () => {
+    const original = createSample({
+      id: 'rt-test',
+      timestamp: 99999,
+      description: 'round-trip',
+      author: 'opus',
+      tags: ['a', 'b'],
+    });
+    const restored = GraphSnapshot.fromJSON(original.toJSON());
+    expect(restored.id).toBe(original.id);
+    expect(restored.timestamp).toBe(original.timestamp);
+    expect(restored.nodes.length).toBe(original.nodes.length);
+    expect(restored.edges.length).toBe(original.edges.length);
+    expect(restored.metadata.description).toBe(original.metadata.description);
+    expect(restored.metadata.author).toBe(original.metadata.author);
+    expect([...restored.metadata.tags]).toEqual([...original.metadata.tags]);
+  });
+
+  it('fromJSON result is also frozen', () => {
+    const snap = GraphSnapshot.fromJSON(createSample().toJSON());
+    expect(Object.isFrozen(snap)).toBe(true);
+    expect(Object.isFrozen(snap.nodes)).toBe(true);
+  });
+});
+
+// ── Diff ─────────────────────────────────────────────────────────────────────
+
+describe('diffSnapshots', () => {
+  it('identical snapshots produce zero diff', () => {
+    const snap = createSample({ id: 'a', timestamp: 1 });
+    const snap2 = createSample({ id: 'b', timestamp: 2 });
+    const diff = diffSnapshots(snap, snap2);
+    expect(diff.summary.totalChanges).toBe(0);
+    expect(diff.summary.hasChanges).toBe(false);
+  });
+
+  it('detects added node', () => {
+    const before = createSample({ id: 'before', timestamp: 1 });
+    const afterNodes = [...sampleNodes(), { id: 'n4', type: 'new', label: 'New' }];
+    const after = new GraphSnapshot(
+      { nodes: afterNodes, edges: sampleEdges() },
+      { id: 'after', timestamp: 2 },
+    );
+    const diff = diffSnapshots(before, after);
+    expect(diff.nodes.added.length).toBe(1);
+    expect(diff.nodes.added[0].id).toBe('n4');
+    expect(diff.summary.nodesAdded).toBe(1);
+    expect(diff.summary.hasChanges).toBe(true);
+  });
+
+  it('detects removed node', () => {
+    const before = createSample({ id: 'before', timestamp: 1 });
+    const afterNodes = sampleNodes().slice(0, 2);
+    const after = new GraphSnapshot(
+      { nodes: afterNodes, edges: [sampleEdges()[0]] },
+      { id: 'after', timestamp: 2 },
+    );
+    const diff = diffSnapshots(before, after);
+    expect(diff.nodes.removed.length).toBe(1);
+    expect(diff.nodes.removed[0].id).toBe('n3');
+    expect(diff.summary.nodesRemoved).toBe(1);
+  });
+
+  it('detects modified node', () => {
+    const before = createSample({ id: 'before', timestamp: 1 });
+    const modifiedNodes = sampleNodes();
+    modifiedNodes[0] = { ...modifiedNodes[0], label: 'AlphaV2' };
+    const after = new GraphSnapshot(
+      { nodes: modifiedNodes, edges: sampleEdges() },
+      { id: 'after', timestamp: 2 },
+    );
+    const diff = diffSnapshots(before, after);
+    expect(diff.nodes.modified.length).toBe(1);
+    expect(diff.nodes.modified[0].id).toBe('n1');
+    expect(diff.nodes.modified[0].changes[0].field).toBe('label');
+    expect(diff.nodes.modified[0].changes[0].before).toBe('Alpha');
+    expect(diff.nodes.modified[0].changes[0].after).toBe('AlphaV2');
+  });
+
+  it('detects added/removed edges', () => {
+    const before = createSample({ id: 'before', timestamp: 1 });
+    const newEdges = [
+      sampleEdges()[0],
+      { id: 'e3', source: 'n1', target: 'n3', type: 'new-edge' },
+    ];
+    const after = new GraphSnapshot(
+      { nodes: sampleNodes(), edges: newEdges },
+      { id: 'after', timestamp: 2 },
+    );
+    const diff = diffSnapshots(before, after);
+    expect(diff.edges.added.length).toBe(1);
+    expect(diff.edges.added[0].id).toBe('e3');
+    expect(diff.edges.removed.length).toBe(1);
+    expect(diff.edges.removed[0].id).toBe('e2');
+  });
+
+  it('diff before/after metadata is correct', () => {
+    const before = createSample({ id: 'snap-a', timestamp: 100 });
+    const after = createSample({ id: 'snap-b', timestamp: 200 });
+    const diff = diffSnapshots(before, after);
+    expect(diff.before.id).toBe('snap-a');
+    expect(diff.before.timestamp).toBe(100);
+    expect(diff.after.id).toBe('snap-b');
+    expect(diff.after.timestamp).toBe(200);
+  });
+});
+
+// ── SnapshotHistory ──────────────────────────────────────────────────────────
+
+describe('SnapshotHistory', () => {
+  it('starts empty', () => {
+    const history = new SnapshotHistory();
+    expect(history.size()).toBe(0);
+    expect(history.getLatest()).toBeUndefined();
+    expect(history.getFirst()).toBeUndefined();
+  });
+
+  it('add increments size', () => {
+    const history = new SnapshotHistory();
+    history.add(createSample({ id: 's1' }));
+    history.add(createSample({ id: 's2' }));
+    expect(history.size()).toBe(2);
+  });
+
+  it('rejects duplicate IDs', () => {
+    const history = new SnapshotHistory();
+    history.add(createSample({ id: 'dup' }));
+    expect(() => history.add(createSample({ id: 'dup' }))).toThrow('already exists');
+  });
+
+  it('getById returns correct snapshot', () => {
+    const history = new SnapshotHistory();
+    const s1 = createSample({ id: 'a' });
+    const s2 = createSample({ id: 'b' });
+    history.add(s1);
+    history.add(s2);
+    expect(history.getById('a')).toBe(s1);
+    expect(history.getById('b')).toBe(s2);
+    expect(history.getById('c')).toBeUndefined();
+  });
+
+  it('getLatest returns last added', () => {
+    const history = new SnapshotHistory();
+    history.add(createSample({ id: 'first' }));
+    history.add(createSample({ id: 'second' }));
+    expect(history.getLatest().id).toBe('second');
+  });
+
+  it('getFirst returns first added', () => {
+    const history = new SnapshotHistory();
+    history.add(createSample({ id: 'first' }));
+    history.add(createSample({ id: 'second' }));
+    expect(history.getFirst().id).toBe('first');
+  });
+
+  it('getByIndex returns correct snapshot', () => {
+    const history = new SnapshotHistory();
+    const s1 = createSample({ id: 'x' });
+    const s2 = createSample({ id: 'y' });
+    history.add(s1);
+    history.add(s2);
+    expect(history.getByIndex(0)).toBe(s1);
+    expect(history.getByIndex(1)).toBe(s2);
+    expect(history.getByIndex(2)).toBeUndefined();
+  });
+
+  it('diff compares two snapshots by ID', () => {
+    const history = new SnapshotHistory();
+    history.add(createSample({ id: 'before', timestamp: 1 }));
+    const afterNodes = [...sampleNodes(), { id: 'n4', type: 'x', label: 'New' }];
+    history.add(new GraphSnapshot({ nodes: afterNodes, edges: sampleEdges() }, { id: 'after', timestamp: 2 }));
+    const diff = history.diff('before', 'after');
+    expect(diff).not.toBeNull();
+    expect(diff.nodes.added.length).toBe(1);
+  });
+
+  it('diff returns null for missing IDs', () => {
+    const history = new SnapshotHistory();
+    history.add(createSample({ id: 'a' }));
+    expect(history.diff('a', 'missing')).toBeNull();
+    expect(history.diff('missing', 'a')).toBeNull();
+  });
+
+  it('diffRange produces sequential diffs', () => {
+    const history = new SnapshotHistory();
+    history.add(new GraphSnapshot({ nodes: [{ id: 'n1', type: 'a', label: 'A' }], edges: [] }, { id: 's1', timestamp: 1 }));
+    history.add(new GraphSnapshot({ nodes: [{ id: 'n1', type: 'a', label: 'A' }, { id: 'n2', type: 'b', label: 'B' }], edges: [] }, { id: 's2', timestamp: 2 }));
+    history.add(new GraphSnapshot({ nodes: [{ id: 'n1', type: 'a', label: 'A' }, { id: 'n2', type: 'b', label: 'B' }, { id: 'n3', type: 'c', label: 'C' }], edges: [] }, { id: 's3', timestamp: 3 }));
+    const diffs = history.diffRange(0, 2);
+    expect(diffs.length).toBe(2);
+    expect(diffs[0].nodes.added.length).toBe(1);
+    expect(diffs[1].nodes.added.length).toBe(1);
+  });
+
+  it('getFullEvolution compares first to last', () => {
+    const history = new SnapshotHistory();
+    history.add(new GraphSnapshot({ nodes: [], edges: [] }, { id: 'first', timestamp: 1 }));
+    history.add(createSample({ id: 'last', timestamp: 2 }));
+    const evo = history.getFullEvolution();
+    expect(evo).not.toBeNull();
+    expect(evo.nodes.added.length).toBe(3);
+    expect(evo.edges.added.length).toBe(2);
+  });
+
+  it('getFullEvolution returns null for single snapshot', () => {
+    const history = new SnapshotHistory();
+    history.add(createSample({ id: 'only' }));
+    expect(history.getFullEvolution()).toBeNull();
+  });
+
+  it('getStats returns correct summary', () => {
+    const history = new SnapshotHistory();
+    history.add(createSample({ id: 'a', timestamp: 100 }));
+    history.add(createSample({ id: 'b', timestamp: 500 }));
+    const stats = history.getStats();
+    expect(stats.count).toBe(2);
+    expect(stats.firstTimestamp).toBe(100);
+    expect(stats.latestTimestamp).toBe(500);
+    expect(stats.timespan).toBe(400);
+    expect(stats.snapshotIds).toEqual(['a', 'b']);
+  });
+
+  it('getStats returns zeroed for empty history', () => {
+    const history = new SnapshotHistory();
+    const stats = history.getStats();
+    expect(stats.count).toBe(0);
+    expect(stats.firstTimestamp).toBeNull();
+    expect(stats.latestTimestamp).toBeNull();
+    expect(stats.timespan).toBe(0);
+  });
+
+  it('clear empties the history', () => {
+    const history = new SnapshotHistory();
+    history.add(createSample({ id: 'a' }));
+    history.add(createSample({ id: 'b' }));
+    history.clear();
+    expect(history.size()).toBe(0);
+    expect(history.getById('a')).toBeUndefined();
+  });
+
+  it('toJSON / fromJSON round-trip preserves history', () => {
+    const history = new SnapshotHistory();
+    history.add(createSample({ id: 'h1', timestamp: 10 }));
+    history.add(createSample({ id: 'h2', timestamp: 20 }));
+    const restored = SnapshotHistory.fromJSON(history.toJSON());
+    expect(restored.size()).toBe(2);
+    expect(restored.getById('h1').timestamp).toBe(10);
+    expect(restored.getById('h2').timestamp).toBe(20);
+    expect(Object.isFrozen(restored.getById('h1'))).toBe(true);
+  });
+});

--- a/src/core/knowledge/__tests__/knowledgeInvariants.test.js
+++ b/src/core/knowledge/__tests__/knowledgeInvariants.test.js
@@ -164,7 +164,7 @@ describe('Knowledge Evolution Invariants', () => {
     expect(result.viewModel.panels.focusNode.id).toBe('root');
   });
 
-  it('KE5 (edge case): empty canonical set → projection on empty graph still total', () => {
+  it('KE5 (edge case): empty canonical set → projection on empty graph returns ok:false', () => {
     const p1 = propose({ subject: 'a', predicate: 'type', object: literal('x') });
     const log = [p1, reject(p1.statement.id)];
 
@@ -173,5 +173,9 @@ describe('Knowledge Evolution Invariants', () => {
 
     const graph = buildGraphFromStatements(canonical);
     expect(graph.getNodes().length).toBe(0);
+
+    const result = projectGraph(graph, { nodeId: null, path: [] }, null, defaultParams());
+    expect(result.ok).toBe(false);
+    expect(result.errors).toContain('graph has no nodes');
   });
 });

--- a/src/core/projection/__tests__/projectionMetadata.test.js
+++ b/src/core/projection/__tests__/projectionMetadata.test.js
@@ -1,0 +1,359 @@
+/**
+ * Projection metadata invariant tests.
+ *
+ * Tests prove:
+ * - INV-1: Schema Conformance — ViewModel output has the declared structure
+ * - INV-2: Identity Stability — node IDs are preserved through projection
+ * - INV-4: Graph Immutability — projection does not mutate input graph
+ *
+ * Uses the test-world fixture (10 nodes, 16 edges).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import { GraphModel } from '../../GraphModel.js';
+import { projectGraph } from '../projectGraph.js';
+import { SemanticRole, defaultParams, emptyFocus } from '../types.js';
+
+const testWorldPath = resolve(import.meta.dirname, '../../../../worlds/test-world/universe.json');
+const raw = JSON.parse(readFileSync(testWorldPath, 'utf-8'));
+const schema = raw.schema;
+
+function loadGraph() {
+  return new GraphModel({ nodes: raw.nodes, links: raw.edges });
+}
+
+// ── INV-1: Schema Conformance ────────────────────────────────────────────────
+
+describe('INV-1: Schema Conformance', () => {
+  it('ViewModel has all required top-level keys: scene, panels, navigation, meta, system', () => {
+    const graph = loadGraph();
+    const result = projectGraph(graph, { nodeId: 'alice', path: [] }, schema, defaultParams());
+    expect(result.ok).toBe(true);
+    const vm = result.viewModel;
+    expect(vm).toHaveProperty('scene');
+    expect(vm).toHaveProperty('panels');
+    expect(vm).toHaveProperty('navigation');
+    expect(vm).toHaveProperty('meta');
+    expect(vm).toHaveProperty('system');
+  });
+
+  it('scene contains nodes and edges arrays', () => {
+    const graph = loadGraph();
+    const { viewModel: vm } = projectGraph(graph, emptyFocus(), schema, defaultParams());
+    expect(Array.isArray(vm.scene.nodes)).toBe(true);
+    expect(Array.isArray(vm.scene.edges)).toBe(true);
+  });
+
+  it('every VisualNode has required fields: id, label, type, role, opacity, metadata', () => {
+    const graph = loadGraph();
+    const { viewModel: vm } = projectGraph(graph, { nodeId: 'alice', path: [] }, schema, defaultParams());
+    for (const node of vm.scene.nodes) {
+      expect(node).toHaveProperty('id');
+      expect(node).toHaveProperty('label');
+      expect(node).toHaveProperty('type');
+      expect(node).toHaveProperty('role');
+      expect(node).toHaveProperty('opacity');
+      expect(node).toHaveProperty('metadata');
+      expect(typeof node.id).toBe('string');
+      expect(typeof node.label).toBe('string');
+      expect(typeof node.type).toBe('string');
+      expect(typeof node.role).toBe('string');
+      expect(typeof node.opacity).toBe('number');
+      expect(typeof node.metadata).toBe('object');
+    }
+  });
+
+  it('VisualNode role is always a valid SemanticRole', () => {
+    const graph = loadGraph();
+    const { viewModel: vm } = projectGraph(graph, { nodeId: 'root', path: [] }, schema, { depth: 2, visibilityMode: 'all' });
+    const validRoles = new Set(Object.values(SemanticRole));
+    for (const node of vm.scene.nodes) {
+      expect(validRoles.has(node.role)).toBe(true);
+    }
+  });
+
+  it('VisualNode opacity is between 0 and 1', () => {
+    const graph = loadGraph();
+    const { viewModel: vm } = projectGraph(graph, { nodeId: 'alice', path: [] }, schema, defaultParams());
+    for (const node of vm.scene.nodes) {
+      expect(node.opacity).toBeGreaterThanOrEqual(0);
+      expect(node.opacity).toBeLessThanOrEqual(1);
+    }
+  });
+
+  it('VisualNode metadata always contains label', () => {
+    const graph = loadGraph();
+    const { viewModel: vm } = projectGraph(graph, emptyFocus(), schema, defaultParams());
+    for (const node of vm.scene.nodes) {
+      expect(node.metadata).toHaveProperty('label');
+      expect(typeof node.metadata.label).toBe('string');
+    }
+  });
+
+  it('every VisualEdge has required fields: id, source, target, type, opacity, touchesFocus', () => {
+    const graph = loadGraph();
+    const { viewModel: vm } = projectGraph(graph, { nodeId: 'alice', path: [] }, schema, defaultParams());
+    for (const edge of vm.scene.edges) {
+      expect(edge).toHaveProperty('id');
+      expect(edge).toHaveProperty('source');
+      expect(edge).toHaveProperty('target');
+      expect(edge).toHaveProperty('type');
+      expect(edge).toHaveProperty('opacity');
+      expect(edge).toHaveProperty('touchesFocus');
+      expect(typeof edge.id).toBe('string');
+      expect(typeof edge.source).toBe('string');
+      expect(typeof edge.target).toBe('string');
+      expect(typeof edge.type).toBe('string');
+      expect(typeof edge.opacity).toBe('number');
+      expect(typeof edge.touchesFocus).toBe('boolean');
+    }
+  });
+
+  it('panels has focusNode, neighbors, breadcrumbs', () => {
+    const graph = loadGraph();
+    const { viewModel: vm } = projectGraph(graph, { nodeId: 'alice', path: ['root'] }, schema, defaultParams());
+    expect(vm.panels).toHaveProperty('focusNode');
+    expect(vm.panels).toHaveProperty('neighbors');
+    expect(vm.panels).toHaveProperty('breadcrumbs');
+    expect(Array.isArray(vm.panels.neighbors)).toBe(true);
+    expect(Array.isArray(vm.panels.breadcrumbs)).toBe(true);
+  });
+
+  it('breadcrumbs have id and label', () => {
+    const graph = loadGraph();
+    const { viewModel: vm } = projectGraph(graph, { nodeId: 'alice', path: ['root', 'hub-people'] }, schema, defaultParams());
+    expect(vm.panels.breadcrumbs.length).toBe(2);
+    for (const crumb of vm.panels.breadcrumbs) {
+      expect(crumb).toHaveProperty('id');
+      expect(crumb).toHaveProperty('label');
+      expect(typeof crumb.id).toBe('string');
+      expect(typeof crumb.label).toBe('string');
+    }
+  });
+
+  it('navigation has canDrillUp, canDrillDown, path', () => {
+    const graph = loadGraph();
+    const { viewModel: vm } = projectGraph(graph, { nodeId: 'alice', path: [] }, schema, defaultParams());
+    expect(vm.navigation).toHaveProperty('canDrillUp');
+    expect(vm.navigation).toHaveProperty('canDrillDown');
+    expect(vm.navigation).toHaveProperty('path');
+    expect(typeof vm.navigation.canDrillUp).toBe('boolean');
+    expect(typeof vm.navigation.canDrillDown).toBe('boolean');
+    expect(Array.isArray(vm.navigation.path)).toBe(true);
+  });
+
+  it('meta has totalNodes, visibleNodes, projectionParams', () => {
+    const graph = loadGraph();
+    const { viewModel: vm } = projectGraph(graph, emptyFocus(), schema, defaultParams());
+    expect(vm.meta).toHaveProperty('totalNodes');
+    expect(vm.meta).toHaveProperty('visibleNodes');
+    expect(vm.meta).toHaveProperty('projectionParams');
+    expect(typeof vm.meta.totalNodes).toBe('number');
+    expect(typeof vm.meta.visibleNodes).toBe('number');
+    expect(typeof vm.meta.projectionParams).toBe('object');
+  });
+
+  it('system has enginePhase, activeFormula, satisfiedInvariants, relatedSpecs, transitions', () => {
+    const graph = loadGraph();
+    const { viewModel: vm } = projectGraph(graph, { nodeId: 'alice', path: [] }, schema, defaultParams());
+    expect(vm.system).toHaveProperty('enginePhase');
+    expect(vm.system).toHaveProperty('activeFormula');
+    expect(vm.system).toHaveProperty('satisfiedInvariants');
+    expect(vm.system).toHaveProperty('relatedSpecs');
+    expect(vm.system).toHaveProperty('transitions');
+    expect(typeof vm.system.enginePhase).toBe('string');
+    expect(typeof vm.system.activeFormula).toBe('string');
+    expect(Array.isArray(vm.system.satisfiedInvariants)).toBe(true);
+    expect(Array.isArray(vm.system.relatedSpecs)).toBe(true);
+    expect(typeof vm.system.transitions).toBe('object');
+  });
+
+  it('satisfiedInvariants always includes INV-1, INV-2, INV-3, INV-4, INV-7', () => {
+    const graph = loadGraph();
+    const { viewModel: vm } = projectGraph(graph, emptyFocus(), schema, defaultParams());
+    const invariants = vm.system.satisfiedInvariants;
+    expect(invariants).toContain('INV-1: Schema Conformance');
+    expect(invariants).toContain('INV-2: Identity Stability');
+    expect(invariants).toContain('INV-3: Projection Determinism');
+    expect(invariants).toContain('INV-4: Graph Immutability');
+    expect(invariants).toContain('INV-7: Totality');
+  });
+
+  it('satisfiedInvariants includes NAV invariants when focus is valid', () => {
+    const graph = loadGraph();
+    const { viewModel: vm } = projectGraph(graph, { nodeId: 'alice', path: ['root'] }, schema, defaultParams());
+    const invariants = vm.system.satisfiedInvariants;
+    expect(invariants).toContain('NAV-1: Transition Validity');
+    expect(invariants).toContain('NAV-4: Determinism');
+    expect(invariants).toContain('NAV-5: Projection Compatibility');
+    expect(invariants).toContain('NAV-2: DrillDown Reversibility');
+    expect(invariants).toContain('NAV-3: History Integrity');
+  });
+
+  it('satisfiedInvariants excludes NAV-2/NAV-3 when path is empty', () => {
+    const graph = loadGraph();
+    const { viewModel: vm } = projectGraph(graph, { nodeId: 'alice', path: [] }, schema, defaultParams());
+    const invariants = vm.system.satisfiedInvariants;
+    expect(invariants).toContain('NAV-1: Transition Validity');
+    expect(invariants).not.toContain('NAV-2: DrillDown Reversibility');
+    expect(invariants).not.toContain('NAV-3: History Integrity');
+  });
+
+  it('transitions.select is always true', () => {
+    const graph = loadGraph();
+    const { viewModel: vm } = projectGraph(graph, emptyFocus(), schema, defaultParams());
+    expect(vm.system.transitions.select).toBe(true);
+  });
+});
+
+// ── INV-2: Identity Stability ────────────────────────────────────────────────
+
+describe('INV-2: Identity Stability', () => {
+  it('every source node ID appears in ViewModel scene', () => {
+    const graph = loadGraph();
+    const { viewModel: vm } = projectGraph(graph, emptyFocus(), schema, defaultParams());
+    const sourceIds = new Set(graph.getNodes().map(n => n.id));
+    const vmIds = new Set(vm.scene.nodes.map(n => n.id));
+    for (const id of sourceIds) {
+      expect(vmIds.has(id)).toBe(true);
+    }
+  });
+
+  it('node IDs are preserved exactly (not transformed)', () => {
+    const graph = loadGraph();
+    const sourceIds = graph.getNodes().map(n => n.id).sort();
+    const { viewModel: vm } = projectGraph(graph, emptyFocus(), schema, defaultParams());
+    const vmIds = vm.scene.nodes.map(n => n.id).sort();
+    expect(vmIds).toEqual(sourceIds);
+  });
+
+  it('edge source/target reference valid node IDs from graph', () => {
+    const graph = loadGraph();
+    const { viewModel: vm } = projectGraph(graph, emptyFocus(), schema, defaultParams());
+    const nodeIds = new Set(graph.getNodes().map(n => n.id));
+    for (const edge of vm.scene.edges) {
+      expect(nodeIds.has(edge.source)).toBe(true);
+      expect(nodeIds.has(edge.target)).toBe(true);
+    }
+  });
+
+  it('focused node ID matches focus input', () => {
+    const graph = loadGraph();
+    const { viewModel: vm } = projectGraph(graph, { nodeId: 'bob', path: [] }, schema, defaultParams());
+    const focusNode = vm.scene.nodes.find(n => n.role === SemanticRole.FOCUS);
+    expect(focusNode).toBeDefined();
+    expect(focusNode.id).toBe('bob');
+  });
+
+  it('identity is stable across repeated projections', () => {
+    const graph = loadGraph();
+    const focus = { nodeId: 'alice', path: [] };
+    const r1 = projectGraph(graph, focus, schema, defaultParams());
+    const r2 = projectGraph(graph, focus, schema, defaultParams());
+    const ids1 = r1.viewModel.scene.nodes.map(n => n.id).sort();
+    const ids2 = r2.viewModel.scene.nodes.map(n => n.id).sort();
+    expect(ids1).toEqual(ids2);
+  });
+
+  it('with focus and depth restriction, visible IDs are a subset of graph IDs', () => {
+    const graph = loadGraph();
+    const { viewModel: vm } = projectGraph(graph, { nodeId: 'alice', path: [] }, schema, { depth: 0, visibilityMode: 'all' });
+    const sourceIds = new Set(graph.getNodes().map(n => n.id));
+    for (const node of vm.scene.nodes) {
+      expect(sourceIds.has(node.id)).toBe(true);
+    }
+  });
+
+  it('edge IDs are preserved from source graph', () => {
+    const graph = loadGraph();
+    const { viewModel: vm } = projectGraph(graph, emptyFocus(), schema, defaultParams());
+    const sourceEdgeIds = new Set(graph.getEdges().map(e => e.id));
+    for (const edge of vm.scene.edges) {
+      expect(sourceEdgeIds.has(edge.id)).toBe(true);
+    }
+  });
+
+  it('panels.breadcrumbs IDs match path node IDs', () => {
+    const graph = loadGraph();
+    const { viewModel: vm } = projectGraph(graph, { nodeId: 'alice', path: ['root', 'hub-people'] }, schema, defaultParams());
+    expect(vm.panels.breadcrumbs.map(b => b.id)).toEqual(['root', 'hub-people']);
+  });
+
+  it('navigation.path IDs match focus path IDs', () => {
+    const graph = loadGraph();
+    const { viewModel: vm } = projectGraph(graph, { nodeId: 'alice', path: ['root', 'hub-people'] }, schema, defaultParams());
+    expect(vm.navigation.path).toEqual(['root', 'hub-people']);
+  });
+});
+
+// ── INV-4: Graph Immutability ────────────────────────────────────────────────
+
+describe('INV-4: Graph Immutability (projection does not mutate input)', () => {
+  it('graph node count unchanged after projection', () => {
+    const graph = loadGraph();
+    const nodesBefore = graph.getNodes().length;
+    projectGraph(graph, { nodeId: 'alice', path: [] }, schema, defaultParams());
+    expect(graph.getNodes().length).toBe(nodesBefore);
+  });
+
+  it('graph edge count unchanged after projection', () => {
+    const graph = loadGraph();
+    const edgesBefore = graph.getEdges().length;
+    projectGraph(graph, { nodeId: 'alice', path: [] }, schema, defaultParams());
+    expect(graph.getEdges().length).toBe(edgesBefore);
+  });
+
+  it('node properties unchanged after projection', () => {
+    const graph = loadGraph();
+    const nodesBefore = JSON.parse(JSON.stringify(graph.getNodes()));
+    projectGraph(graph, { nodeId: 'alice', path: ['root'] }, schema, defaultParams());
+    const nodesAfter = graph.getNodes();
+    expect(nodesAfter).toEqual(nodesBefore);
+  });
+
+  it('edge properties unchanged after projection', () => {
+    const graph = loadGraph();
+    const edgesBefore = JSON.parse(JSON.stringify(graph.getEdges()));
+    projectGraph(graph, { nodeId: 'alice', path: ['root'] }, schema, defaultParams());
+    const edgesAfter = graph.getEdges();
+    expect(edgesAfter).toEqual(edgesBefore);
+  });
+
+  it('graph unchanged after multiple projections with different foci', () => {
+    const graph = loadGraph();
+    const snapshot = JSON.parse(JSON.stringify({
+      nodes: graph.getNodes(),
+      edges: graph.getEdges(),
+    }));
+
+    projectGraph(graph, emptyFocus(), schema, defaultParams());
+    projectGraph(graph, { nodeId: 'alice', path: [] }, schema, defaultParams());
+    projectGraph(graph, { nodeId: 'root', path: [] }, schema, { depth: 2, visibilityMode: 'all' });
+    projectGraph(graph, { nodeId: 'bob', path: ['root', 'hub-people'] }, schema, defaultParams());
+
+    expect(graph.getNodes()).toEqual(snapshot.nodes);
+    expect(graph.getEdges()).toEqual(snapshot.edges);
+  });
+
+  it('graph unchanged after projection with invalid focus (error path)', () => {
+    const graph = loadGraph();
+    const snapshot = JSON.parse(JSON.stringify({
+      nodes: graph.getNodes(),
+      edges: graph.getEdges(),
+    }));
+    const result = projectGraph(graph, { nodeId: 'nonexistent', path: [] }, schema, defaultParams());
+    expect(result.ok).toBe(false);
+    expect(graph.getNodes()).toEqual(snapshot.nodes);
+    expect(graph.getEdges()).toEqual(snapshot.edges);
+  });
+
+  it('getNodeById still works correctly after projection', () => {
+    const graph = loadGraph();
+    const aliceBefore = graph.getNodeById('alice');
+    projectGraph(graph, { nodeId: 'bob', path: [] }, schema, defaultParams());
+    const aliceAfter = graph.getNodeById('alice');
+    expect(aliceAfter).toEqual(aliceBefore);
+  });
+});


### PR DESCRIPTION
## Goal

Close the remaining Block B evidence gaps identified in B1/B2:
- Projection metadata invariants (INV-1, INV-2, INV-4)
- GraphSnapshot immutability guarantees
- KE5 empty-graph edge case

Closes #11

## Non-goals

- No projection pipeline redesign
- No ViewModel schema changes
- No public promise expansion
- No runtime behavior changes

## What changed

### New test files
- `src/core/projection/__tests__/projectionMetadata.test.js` (32 tests)
  - INV-1 Schema Conformance: 15 tests
  - INV-2 Identity Stability: 9 tests
  - INV-4 Graph Immutability: 7 tests + 1 error path
- `src/core/__tests__/GraphSnapshot.test.js` (62 tests)
  - Creation: 12 tests
  - Immutability/freeze: 13 tests
  - Accessors: 8 tests
  - Statistics: 4 tests
  - Serialization: 4 tests
  - diffSnapshots: 6 tests
  - SnapshotHistory: 15 tests

### Modified files
- `src/core/knowledge/__tests__/knowledgeInvariants.test.js`: KE5 edge case now calls `projectGraph` on empty graph and asserts `{ ok: false, errors: ['graph has no nodes'] }`
- `docs/INVARIANT_MATRIX.md`: INV-1, INV-2, INV-4 upgraded to evidenced; KE5 upgraded to evidenced; summary now 44/44
- `docs/PROOF_OBLIGATIONS.md`: all Important gaps closed; projection section updated to strong evidence

## Evidence gaps addressed

| Gap (from B1/B2) | Status |
|---|---|
| INV-1 (schema conformance) | CLOSED |
| INV-2 (identity stability) | CLOSED |
| INV-4 (graph immutability) | CLOSED |
| GraphSnapshot immutability | CLOSED |
| KE5 empty-graph edge case | CLOSED |

## Bugs found

None. The projection pipeline and GraphSnapshot implementation are correct as-is.

## Acceptance checklist

- [x] INV-1 tested (15 tests)
- [x] INV-2 tested (9 tests)
- [x] INV-4 tested (7 tests)
- [x] GraphSnapshot tested (62 tests)
- [x] KE5 edge case tested
- [x] Evidence docs updated (44/44 evidenced)
- [x] All 849 tests pass
- [x] No runtime/API changes

## Files changed

- `src/core/projection/__tests__/projectionMetadata.test.js` (new)
- `src/core/__tests__/GraphSnapshot.test.js` (new)
- `src/core/knowledge/__tests__/knowledgeInvariants.test.js` (modified)
- `docs/INVARIANT_MATRIX.md` (modified)
- `docs/PROOF_OBLIGATIONS.md` (modified)
