### PR TITLE
E1: Traceability reference world and demo pack

### DIFF
--- a/worlds/traceability-world/TRACEABILITY_CASE.md
+++ b/worlds/traceability-world/TRACEABILITY_CASE.md
@@ -1,0 +1,159 @@
+# Traceability Case — Authentication Module
+
+This document explains the traceability reference world and its scenarios. It is the first external proof case for Meaning Engine, demonstrating that the engine can operate on an engineering-recognizable problem: tracing requirements through implementation to test evidence.
+
+## What the world models
+
+The world represents an authentication module with 21 nodes and 22 edges across 5 entity types:
+
+| Type | Count | Examples |
+|------|-------|---------|
+| **spec** | 4 | User authentication, session expiry, account lockout, password reset |
+| **concept** | 6 | Credential validation, session lifecycle, security boundary, test coverage |
+| **invariant** | 2 | No plaintext password storage, audit trail for auth events |
+| **code_artifact** | 5 | authService.js, sessionManager.js, passwordHash.js, lockoutHandler.js, resetHandler.js |
+| **evidence** | 4 | login.test.js, session.test.js, hash.test.js, lockout.test.js |
+
+The graph uses 5 edge types following existing Meaning Engine conventions:
+
+| Edge type | Direction | Meaning |
+|-----------|-----------|---------|
+| `defines` | spec → concept | Spec introduces a concept |
+| `constrains` | concept → invariant | Concept imposes a constraint |
+| `proved_by` | invariant/code/concept → evidence | Entity is proved by evidence |
+| `implements` | code_artifact → spec | Code implements a spec |
+| `depends_on` | code → code, concept → concept | Dependency relation |
+
+### Deliberate design choices
+
+- **One deliberate gap**: `spec:password-reset` has a concept and code implementation but **no test evidence**. The `resetHandler.js` is isolated from the evidence layer — there are no `proved_by` edges from it.
+- **Two rival paths**: `spec:auth-login` reaches `evidence:login-tests` through two equally short 2-hop paths: one via `concept:credential-validation` (abstraction layer) and one via `code_artifact:authService` (implementation layer).
+- **Bridge concepts**: `concept:test-coverage` and `concept:code-spec-alignment` exist in the graph to enable Meaning Engine's bridge candidate detection when gaps are found.
+
+## Scenarios
+
+### S1: Spec → Evidence traceability
+
+**Question**: Can we trace from a requirement to its test evidence?
+
+```
+trace(spec:auth-login → evidence:login-tests)
+→ PATH FOUND (2 hops)
+→ spec:auth-login → concept:credential-validation → evidence:login-tests
+```
+
+**What this shows**: The engine finds a directed path from requirement to test evidence, traversing the concept layer. This is the basic traceability operation.
+
+### S2: Rival implementation paths
+
+**Question**: Are there multiple routes from a spec to its evidence?
+
+```
+compare(spec:auth-login, evidence:login-tests)
+→ 2 RIVAL PATHS
+  Path 1: spec → concept:credential-validation → evidence  (concept-heavy)
+  Path 2: spec → code:authService → evidence               (code-heavy)
+```
+
+**What this shows**: The compare operator detects that the same spec-to-evidence connection exists via two structurally different paths. The clustering engine labels them by structural signature (concept-heavy vs code-heavy). This helps an engineer see that the requirement is covered from both an abstract and an implementation perspective.
+
+### S3: Gap detection
+
+**Question**: Does the password-reset spec have test evidence?
+
+```
+trace(spec:password-reset → any evidence)
+→ NO PATH
+
+Bridge candidates suggested:
+  - concept:test-coverage
+  - concept:acceptance-criteria
+  - concept:verification-method
+```
+
+**What this shows**: The engine identifies that `spec:password-reset` has no traceable path to any evidence node. It suggests bridge concepts that could close the gap. In a real project, this signals a missing test or an unverified requirement.
+
+### S4: Invariant enforcement trace
+
+**Question**: Can we trace constraints to their evidence?
+
+```
+trace(invariant:no-plaintext → evidence:hash-tests) → PATH FOUND (1 hop)
+trace(invariant:audit-trail → evidence:login-tests) → PATH FOUND (1 hop)
+trace(code:authService → spec:auth-login) → PATH FOUND (1 hop)
+```
+
+**What this shows**: Invariants (constraints) are directly linked to evidence. Code artifacts trace back to their specs via `implements` edges. This confirms that the constraint enforcement chain is intact.
+
+### S5: Focused projection
+
+**Question**: What does the local structure around a requirement look like?
+
+```
+projectGraph(focus: spec:auth-login)
+→ 4 visible nodes, 4 visible edges
+→ Neighbors: credential-validation, security-boundary, authService
+→ canDrillDown: true
+```
+
+**What this shows**: The projection engine correctly builds a focused view of the graph around a single node, showing its immediate neighborhood. This is the basic exploration operation for understanding local structure.
+
+## Why this is an engineering-relevant proof case
+
+1. **Recognizable problem**: Every engineering team deals with spec-to-test traceability. The problem domain requires no explanation.
+
+2. **Current engine strengths**: The scenarios use only existing stable-core capabilities: `trace`, `compare`, `projectGraph`, and `supports*` operators. No new capabilities were added.
+
+3. **Honest gap**: The deliberate gap (password-reset without tests) demonstrates that the engine can identify missing coverage, not just confirm existing links.
+
+4. **Structural insight**: The rival path detection shows that the engine provides structural analysis beyond simple yes/no connectivity.
+
+## What this does NOT demonstrate
+
+- **Large-scale traceability**: This is a 21-node world. Real codebases have thousands of files and specs. The engine has been benchmarked up to 2,500 nodes (see `docs/OPERATIONAL_LIMITS.md`), but the traceability world does not prove large-scale readiness.
+
+- **Real-time updates**: The world is static. There is no demonstration of live graph mutation as code or tests change.
+
+- **External tool integration**: The world is self-contained. There is no import from Jira, GitHub Issues, or a test runner.
+
+- **Automated remediation**: The engine detects gaps but does not suggest fixes beyond bridge concepts. It does not generate tests or link missing specs.
+
+- **Industrial compliance**: This is a proof-of-utility case, not a compliance solution. It demonstrates the mechanism, not regulatory conformance.
+
+## How to run
+
+```bash
+# Run the demo script
+node --experimental-vm-modules worlds/traceability-world/demo.js
+
+# Run the automated tests
+npm test -- worlds/traceability-world/__tests__/traceabilityWorld.test.js
+```
+
+## Graph topology
+
+```
+spec:auth-login ──defines──→ concept:credential-validation ──proved_by──→ evidence:login-tests
+       │                              │                                         ▲
+       │ ──defines──→ concept:security-boundary ──constrains──→ invariant:no-plaintext ──proved_by──→ evidence:hash-tests
+       │                    │                                                    ▲
+       ▲                    └──depends_on──→ concept:credential-validation       │
+code:authService ──implements──┘                    │                            │
+       │                                   constrains ──→ invariant:audit-trail ──proved_by──→ evidence:login-tests
+       ├──depends_on──→ code:passwordHash ──proved_by──→ evidence:hash-tests
+       ├──depends_on──→ code:sessionManager ──proved_by──→ evidence:session-tests
+       └──proved_by──→ evidence:login-tests
+
+spec:password-reset ──defines──→ concept:password-recovery  (dead end — no evidence)
+       ▲
+code:resetHandler ──implements──┘                           (no proved_by — GAP)
+
+spec:session-expiry ──defines──→ concept:session-lifecycle ──proved_by──→ evidence:session-tests
+       ▲
+code:sessionManager ──implements──┘
+
+spec:account-lockout
+       ▲
+code:lockoutHandler ──implements──┘ ──proved_by──→ evidence:lockout-tests
+       └──depends_on──→ code:authService
+```

--- a/worlds/traceability-world/__tests__/traceabilityWorld.test.js
+++ b/worlds/traceability-world/__tests__/traceabilityWorld.test.js
@@ -1,0 +1,260 @@
+/**
+ * Traceability World — Smoke tests + Scenario pack (5 scenarios)
+ *
+ * Validates that:
+ *   - the world loads correctly and graph integrity holds
+ *   - spec → evidence traceability works through concept/invariant layers
+ *   - rival implementation paths are detected (concept vs code path)
+ *   - a deliberate gap is detected (password-reset has no test evidence)
+ *   - invariant → evidence tracing works
+ *   - projection produces a valid ViewModel with focus
+ */
+
+import { describe, test, expect, beforeAll } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { loadTraceabilityWorld } from '../loader.js';
+import { trace } from '../../../operators/trace.js';
+import { compare } from '../../../operators/compare.js';
+import {
+  supportsInspect,
+  supportsTrace,
+  supportsCompare,
+  supportsBridgeCandidates,
+  rankBridgeCandidates,
+} from '../../../operators/supports.js';
+import { projectGraph } from '../../../src/core/projection/projectGraph.js';
+import { defaultParams } from '../../../src/core/projection/types.js';
+
+const __dir = dirname(fileURLToPath(import.meta.url));
+const worldDir = resolve(__dir, '..');
+
+let graphModel;
+let rawGraph;
+
+beforeAll(() => {
+  const result = loadTraceabilityWorld();
+  graphModel = result.graph;
+
+  const rawN = JSON.parse(readFileSync(resolve(worldDir, 'seed.nodes.json'), 'utf-8'));
+  const rawE = JSON.parse(readFileSync(resolve(worldDir, 'seed.edges.json'), 'utf-8'));
+  rawGraph = { nodes: rawN, edges: rawE };
+});
+
+describe('Traceability World — Smoke Tests', () => {
+  test('loader returns graph and meta', () => {
+    const { graph, meta } = loadTraceabilityWorld();
+    expect(graph).toBeDefined();
+    expect(meta.nodeCount).toBe(21);
+    expect(meta.edgeCount).toBe(22);
+    expect(meta.nodeTypes).toContain('spec');
+    expect(meta.nodeTypes).toContain('concept');
+    expect(meta.nodeTypes).toContain('invariant');
+    expect(meta.nodeTypes).toContain('evidence');
+    expect(meta.nodeTypes).toContain('code_artifact');
+  });
+
+  test('GraphModel instance has correct node/edge counts', () => {
+    expect(graphModel.getNodes().length).toBe(21);
+    expect(graphModel.getEdges().length).toBe(22);
+  });
+
+  test('all nodes have id, type, and title', () => {
+    for (const n of rawGraph.nodes) {
+      expect(n.id).toBeTruthy();
+      expect(n.type).toBeTruthy();
+      expect(n.title).toBeTruthy();
+    }
+  });
+
+  test('all edges reference existing nodes', () => {
+    const nodeIds = new Set(rawGraph.nodes.map((n) => n.id));
+    for (const e of rawGraph.edges) {
+      expect(nodeIds.has(e.source)).toBe(true);
+      expect(nodeIds.has(e.target)).toBe(true);
+    }
+  });
+
+  test('no duplicate node IDs', () => {
+    const ids = rawGraph.nodes.map((n) => n.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  test('supportsInspect returns ok', () => {
+    expect(supportsInspect(rawGraph).ok).toBe(true);
+  });
+
+  test('supportsTrace returns ok', () => {
+    expect(supportsTrace(rawGraph).ok).toBe(true);
+  });
+});
+
+describe('Traceability World — 5 Scenarios', () => {
+
+  // ─── S1: Spec → Evidence traceability (success) ───────────────────────
+  describe('S1: Spec → Evidence traceability', () => {
+    test('trace(auth-login → login-tests) finds a directed path', () => {
+      const result = trace(rawGraph, 'spec:auth-login', 'evidence:login-tests');
+      expect(result.hops).toBeGreaterThanOrEqual(2);
+      expect(result.hops).toBeLessThanOrEqual(4);
+    });
+
+    test('path passes through concept layer', () => {
+      const result = trace(rawGraph, 'spec:auth-login', 'evidence:login-tests');
+      const pathIds = result.path.map((s) => s.nodeId);
+      expect(pathIds).toContain('spec:auth-login');
+      expect(pathIds).toContain('evidence:login-tests');
+      const middleTypes = result.path
+        .slice(1, -1)
+        .map((s) => rawGraph.nodes.find((n) => n.id === s.nodeId)?.type);
+      expect(middleTypes).toContain('concept');
+    });
+
+    test('session-expiry also traces to session-tests', () => {
+      const result = trace(rawGraph, 'spec:session-expiry', 'evidence:session-tests');
+      expect(result.hops).toBeGreaterThanOrEqual(2);
+    });
+  });
+
+  // ─── S2: Rival paths (concept path vs code path) ─────────────────────
+  describe('S2: Rival implementation paths', () => {
+    test('compare(auth-login, login-tests) finds ≥ 2 rival paths', () => {
+      const result = compare(rawGraph, 'spec:auth-login', 'evidence:login-tests');
+      expect(result.ok).toBe(true);
+      expect(result.pathCount).toBeGreaterThanOrEqual(2);
+    });
+
+    test('supportsCompare returns ok for auth-login → login-tests', () => {
+      const result = supportsCompare(rawGraph, 'spec:auth-login', 'evidence:login-tests');
+      expect(result.ok).toBe(true);
+    });
+
+    test('rival paths show different structural signatures', () => {
+      const result = compare(rawGraph, 'spec:auth-login', 'evidence:login-tests');
+      const paths = result.paths;
+      const hasConceptPath = paths.some(
+        (p) => (p.nodeTypeHistogram['concept'] || 0) >= 1,
+      );
+      const hasCodePath = paths.some(
+        (p) => (p.nodeTypeHistogram['code_artifact'] || 0) >= 1,
+      );
+      expect(hasConceptPath).toBe(true);
+      expect(hasCodePath).toBe(true);
+    });
+  });
+
+  // ─── S3: Gap detection (password-reset has no evidence) ───────────────
+  describe('S3: Gap detection — password-reset has no test evidence', () => {
+    test('trace(password-reset → login-tests) = no path', () => {
+      const result = trace(rawGraph, 'spec:password-reset', 'evidence:login-tests');
+      expect(result.hops).toBeUndefined();
+    });
+
+    test('trace(password-reset → any evidence) finds no path', () => {
+      const evidenceIds = rawGraph.nodes
+        .filter((n) => n.type === 'evidence')
+        .map((n) => n.id);
+      for (const eid of evidenceIds) {
+        const result = trace(rawGraph, 'spec:password-reset', eid);
+        expect(result.hops).toBeUndefined();
+      }
+    });
+
+    test('bridge candidates are suggested for password-reset → evidence gap', () => {
+      const result = supportsBridgeCandidates(
+        rawGraph,
+        'spec:password-reset',
+        'evidence:login-tests',
+      );
+      expect(result.ok).toBe(true);
+      expect(result.detail.candidateCount).toBeGreaterThanOrEqual(1);
+    });
+
+    test('rankBridgeCandidates returns concept:test-coverage as candidate', () => {
+      const candidates = rankBridgeCandidates(
+        { fromId: 'spec:password-reset', toId: 'evidence:login-tests' },
+        rawGraph,
+      );
+      expect(candidates.length).toBeGreaterThanOrEqual(1);
+      const conceptIds = candidates.map((c) => c.candidateConceptId);
+      expect(conceptIds).toContain('concept:test-coverage');
+    });
+  });
+
+  // ─── S4: Invariant → Evidence trace ──────────────────────────────────
+  describe('S4: Invariant enforcement trace', () => {
+    test('trace(no-plaintext → hash-tests) finds direct path', () => {
+      const result = trace(rawGraph, 'invariant:no-plaintext', 'evidence:hash-tests');
+      expect(result.hops).toBe(1);
+    });
+
+    test('trace(audit-trail → login-tests) finds direct path', () => {
+      const result = trace(rawGraph, 'invariant:audit-trail', 'evidence:login-tests');
+      expect(result.hops).toBe(1);
+    });
+
+    test('code implements spec: authService → auth-login in 1 hop', () => {
+      const result = trace(rawGraph, 'code_artifact:authService', 'spec:auth-login');
+      expect(result.hops).toBe(1);
+    });
+  });
+
+  // ─── S5: Projection with focus ──────────────────────────────────────
+  describe('S5: Projection', () => {
+    test('projectGraph with focus on spec:auth-login returns ok', () => {
+      const result = projectGraph(
+        graphModel,
+        { nodeId: 'spec:auth-login', path: [] },
+        null,
+        defaultParams(),
+      );
+      expect(result.ok).toBe(true);
+      expect(result.viewModel.scene.nodes.length).toBeGreaterThanOrEqual(1);
+    });
+
+    test('focused projection shows neighbors of auth-login', () => {
+      const result = projectGraph(
+        graphModel,
+        { nodeId: 'spec:auth-login', path: [] },
+        null,
+        defaultParams(),
+      );
+      const nodeIds = result.viewModel.scene.nodes.map((n) => n.id);
+      expect(nodeIds).toContain('spec:auth-login');
+      expect(nodeIds).toContain('concept:credential-validation');
+    });
+
+    test('no-focus projection includes all nodes', () => {
+      const result = projectGraph(
+        graphModel,
+        { nodeId: null, path: [] },
+        null,
+        defaultParams(),
+      );
+      expect(result.ok).toBe(true);
+      expect(result.viewModel.scene.nodes.length).toBe(21);
+    });
+  });
+
+  // ─── Determinism + no-mutation ──────────────────────────────────────
+  test('all scenarios are deterministic across runs', () => {
+    const r1 = trace(rawGraph, 'spec:auth-login', 'evidence:login-tests');
+    const r2 = trace(rawGraph, 'spec:auth-login', 'evidence:login-tests');
+    expect(r1.hops).toBe(r2.hops);
+
+    const c1 = compare(rawGraph, 'spec:auth-login', 'evidence:login-tests');
+    const c2 = compare(rawGraph, 'spec:auth-login', 'evidence:login-tests');
+    expect(c1.pathCount).toBe(c2.pathCount);
+  });
+
+  test('exploration does not mutate the graph', () => {
+    const nodesBefore = rawGraph.nodes.length;
+    const edgesBefore = rawGraph.edges.length;
+    trace(rawGraph, 'spec:auth-login', 'evidence:login-tests');
+    compare(rawGraph, 'spec:auth-login', 'evidence:login-tests');
+    trace(rawGraph, 'spec:password-reset', 'evidence:login-tests');
+    expect(rawGraph.nodes.length).toBe(nodesBefore);
+    expect(rawGraph.edges.length).toBe(edgesBefore);
+  });
+});

--- a/worlds/traceability-world/demo.js
+++ b/worlds/traceability-world/demo.js
@@ -1,0 +1,216 @@
+/**
+ * Traceability World — Demo Pack
+ *
+ * Runs 5 scenarios demonstrating Meaning Engine capabilities on a
+ * spec → code → test traceability graph for an authentication module.
+ *
+ * Usage:
+ *   node --experimental-vm-modules worlds/traceability-world/demo.js
+ */
+
+import { readFileSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { GraphModel } from '../../src/core/index.js';
+import { projectGraph } from '../../src/core/projection/projectGraph.js';
+import { defaultParams } from '../../src/core/projection/types.js';
+import { trace } from '../../operators/trace.js';
+import { compare } from '../../operators/compare.js';
+import {
+  supportsInspect,
+  supportsTrace,
+  rankBridgeCandidates,
+} from '../../operators/supports.js';
+
+const __dir = dirname(fileURLToPath(import.meta.url));
+
+const nodesRaw = JSON.parse(readFileSync(resolve(__dir, 'seed.nodes.json'), 'utf-8'));
+const edgesRaw = JSON.parse(readFileSync(resolve(__dir, 'seed.edges.json'), 'utf-8'));
+const rawGraph = { nodes: nodesRaw, edges: edgesRaw };
+const graphModel = new GraphModel({
+  nodes: nodesRaw.map((n) => ({ ...n, label: n.title })),
+  edges: edgesRaw.map((e, i) => ({ id: `trace-edge-${i}`, ...e })),
+});
+
+function hr(title) {
+  console.log(`\n${'─'.repeat(60)}`);
+  console.log(`  ${title}`);
+  console.log('─'.repeat(60));
+}
+
+function printPath(result) {
+  if (!result.path || result.path.length === 0) return;
+  const steps = result.path.map((s) => {
+    const node = nodesRaw.find((n) => n.id === s.nodeId);
+    return `${s.nodeId} (${node?.type || '?'})`;
+  });
+  console.log(`  Path: ${steps.join(' → ')}`);
+}
+
+// ─── World overview ──────────────────────────────────────────────────────────
+
+console.log('Meaning Engine — Traceability World Demo');
+console.log(`Date: ${new Date().toISOString()}\n`);
+console.log(`World: Authentication Module Traceability`);
+console.log(`  Nodes: ${nodesRaw.length}`);
+console.log(`  Edges: ${edgesRaw.length}`);
+console.log(`  Node types: ${[...new Set(nodesRaw.map((n) => n.type))].join(', ')}`);
+console.log(`  Edge types: ${[...new Set(edgesRaw.map((e) => e.type))].join(', ')}`);
+
+const inspect = supportsInspect(rawGraph);
+const traceSupport = supportsTrace(rawGraph);
+console.log(`\n  supportsInspect: ${inspect.ok ? 'ok' : 'FAIL'}`);
+console.log(`  supportsTrace:   ${traceSupport.ok ? 'ok' : 'FAIL'}`);
+
+// ─── Scenario 1: Spec → Evidence traceability ───────────────────────────────
+
+hr('Scenario 1: Spec → Evidence Traceability');
+console.log('  Question: Can we trace from a requirement to its test evidence?\n');
+
+const s1 = trace(rawGraph, 'spec:auth-login', 'evidence:login-tests');
+console.log(`  trace(spec:auth-login → evidence:login-tests)`);
+console.log(`  Result: ${s1.hops !== undefined ? `PATH FOUND (${s1.hops} hops)` : 'NO PATH'}`);
+printPath(s1);
+
+const s1b = trace(rawGraph, 'spec:session-expiry', 'evidence:session-tests');
+console.log(`\n  trace(spec:session-expiry → evidence:session-tests)`);
+console.log(`  Result: ${s1b.hops !== undefined ? `PATH FOUND (${s1b.hops} hops)` : 'NO PATH'}`);
+printPath(s1b);
+
+console.log('\n  ✓ Both specs have traceable paths to their evidence.');
+console.log('  Interpretation: the concept/invariant layers provide the semantic bridge.');
+
+// ─── Scenario 2: Rival implementation paths ─────────────────────────────────
+
+hr('Scenario 2: Rival Implementation Paths');
+console.log('  Question: Are there multiple routes from spec to evidence?\n');
+
+const s2 = compare(rawGraph, 'spec:auth-login', 'evidence:login-tests');
+console.log(`  compare(spec:auth-login, evidence:login-tests)`);
+console.log(`  Result: ${s2.ok ? `${s2.pathCount} RIVAL PATHS` : `no rivals (${s2.note})`}`);
+
+if (s2.paths && s2.paths.length > 0) {
+  for (let i = 0; i < s2.paths.length; i++) {
+    const p = s2.paths[i];
+    const route = (p.nodeTitles || p.nodeIds || []).join(' → ');
+    const types = Object.entries(p.nodeTypeHistogram || {})
+      .map(([t, c]) => `${t}:${c}`)
+      .join(', ');
+    console.log(`    Path ${i + 1}: ${route}`);
+    console.log(`      Types: ${types}`);
+  }
+}
+
+if (s2.clusters && s2.clusters.length > 0) {
+  console.log(`\n  Clusters: ${s2.clusters.length}`);
+  for (const cl of s2.clusters) {
+    console.log(`    - "${cl.labels?.join(', ')}" (${cl.count} paths)`);
+  }
+}
+
+console.log('\n  ✓ Multiple paths exist — one through code, one through concepts.');
+console.log('  Interpretation: the spec reaches evidence via both implementation and abstraction layers.');
+
+// ─── Scenario 3: Gap detection ──────────────────────────────────────────────
+
+hr('Scenario 3: Gap Detection — Missing Test Evidence');
+console.log('  Question: Does the password-reset spec have test evidence?\n');
+
+const evidenceIds = nodesRaw.filter((n) => n.type === 'evidence').map((n) => n.id);
+let gapFound = true;
+for (const eid of evidenceIds) {
+  const result = trace(rawGraph, 'spec:password-reset', eid);
+  if (result.hops !== undefined) {
+    console.log(`  trace(spec:password-reset → ${eid}): PATH FOUND (${result.hops} hops)`);
+    gapFound = false;
+  }
+}
+if (gapFound) {
+  console.log('  trace(spec:password-reset → any evidence): NO PATH');
+}
+
+const candidates = rankBridgeCandidates(
+  { fromId: 'spec:password-reset', toId: 'evidence:login-tests' },
+  rawGraph,
+);
+if (candidates.length > 0) {
+  console.log(`\n  Bridge candidates suggested:`);
+  for (const c of candidates) {
+    console.log(`    - ${c.candidateConceptId} (score: ${c.score})`);
+  }
+}
+
+console.log('\n  ⚠ GAP: spec:password-reset has code (resetHandler.js) but no tests.');
+console.log('  The password recovery feature has a defined concept and implementation');
+console.log('  but no evidence proving it works. This is a traceability gap.');
+
+// ─── Scenario 4: Invariant enforcement trace ────────────────────────────────
+
+hr('Scenario 4: Invariant Enforcement Trace');
+console.log('  Question: Can we trace invariants to their evidence?\n');
+
+const s4a = trace(rawGraph, 'invariant:no-plaintext', 'evidence:hash-tests');
+console.log(`  trace(invariant:no-plaintext → evidence:hash-tests)`);
+console.log(`  Result: ${s4a.hops !== undefined ? `PATH FOUND (${s4a.hops} hops)` : 'NO PATH'}`);
+printPath(s4a);
+
+const s4b = trace(rawGraph, 'invariant:audit-trail', 'evidence:login-tests');
+console.log(`\n  trace(invariant:audit-trail → evidence:login-tests)`);
+console.log(`  Result: ${s4b.hops !== undefined ? `PATH FOUND (${s4b.hops} hops)` : 'NO PATH'}`);
+printPath(s4b);
+
+const s4c = trace(rawGraph, 'code_artifact:authService', 'spec:auth-login');
+console.log(`\n  trace(code:authService → spec:auth-login)`);
+console.log(`  Result: ${s4c.hops !== undefined ? `PATH FOUND (${s4c.hops} hops)` : 'NO PATH'}`);
+printPath(s4c);
+
+console.log('\n  ✓ Both invariants trace directly to evidence.');
+console.log('  ✓ Code traces back to spec via implements edge.');
+
+// ─── Scenario 5: Projection ─────────────────────────────────────────────────
+
+hr('Scenario 5: Focused Projection');
+console.log('  Question: What does the neighborhood of spec:auth-login look like?\n');
+
+const s5 = projectGraph(
+  graphModel,
+  { nodeId: 'spec:auth-login', path: [] },
+  null,
+  defaultParams(),
+);
+if (s5.ok) {
+  const vm = s5.viewModel;
+  console.log(`  Focus: spec:auth-login`);
+  console.log(`  Visible nodes: ${vm.scene.nodes.length}`);
+  console.log(`  Visible edges: ${vm.scene.edges.length}`);
+  console.log(`  Neighbors: ${vm.panels.neighbors.map((n) => n.id).join(', ')}`);
+  console.log(`  Focus type: ${vm.panels.focusNode.type}`);
+  console.log(`  Navigation: canDrillDown=${vm.navigation.canDrillDown}, canDrillUp=${vm.navigation.canDrillUp}`);
+}
+
+console.log('\n  ✓ Projection reveals the local structure around the focused requirement.');
+
+// ─── Summary ─────────────────────────────────────────────────────────────────
+
+hr('Summary');
+console.log(`
+  This demo shows Meaning Engine operating on a realistic engineering problem:
+  tracing requirements through implementation to test evidence.
+
+  ┌─────────────────────────────────────────────────────────┐
+  │ Demonstrated capabilities:                              │
+  │  • Directed trace through concept/invariant layers      │
+  │  • Rival path detection (concept vs code paths)         │
+  │  • Gap detection with bridge candidates                 │
+  │  • Invariant enforcement tracing                        │
+  │  • Focused projection of local structure                │
+  ├─────────────────────────────────────────────────────────┤
+  │ Not demonstrated:                                       │
+  │  • Large-scale traceability (this is a 21-node world)   │
+  │  • Real-time or incremental graph updates               │
+  │  • Integration with external ALM/test tooling           │
+  │  • Automated gap remediation                            │
+  └─────────────────────────────────────────────────────────┘
+`);
+
+console.log('Done.');

--- a/worlds/traceability-world/loader.js
+++ b/worlds/traceability-world/loader.js
@@ -1,0 +1,62 @@
+/**
+ * Traceability World loader.
+ *
+ * A compact reference world modeling spec → code → test traceability
+ * for an authentication module. Designed to demonstrate Meaning Engine's
+ * trace, compare, gap detection, and projection capabilities.
+ *
+ * Usage:
+ *   import { loadTraceabilityWorld } from './loader.js';
+ *   const { graph, meta } = loadTraceabilityWorld();
+ */
+
+import { readFileSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { GraphModel } from '../../src/core/index.js';
+
+const __dirname_resolved =
+  typeof __dirname !== 'undefined'
+    ? __dirname
+    : dirname(fileURLToPath(import.meta.url));
+
+export function loadTraceabilityWorld() {
+  const nodesRaw = JSON.parse(
+    readFileSync(resolve(__dirname_resolved, 'seed.nodes.json'), 'utf-8'),
+  );
+  const edgesRaw = JSON.parse(
+    readFileSync(resolve(__dirname_resolved, 'seed.edges.json'), 'utf-8'),
+  );
+
+  const nodes = nodesRaw.map((n) => ({
+    id: n.id,
+    type: n.type,
+    label: n.title,
+    ...n,
+  }));
+
+  const edges = edgesRaw.map((e, i) => ({
+    id: e.id ?? `trace-edge-${i}`,
+    source: e.source,
+    target: e.target,
+    type: e.type,
+    layer: e.layer,
+  }));
+
+  const graph = new GraphModel({ nodes, edges });
+
+  const nodeTypes = [...new Set(nodes.map((n) => n.type))];
+  const edgeTypes = [...new Set(edges.map((e) => e.type))];
+
+  return {
+    graph,
+    meta: {
+      name: 'traceability-world',
+      description: 'Spec → Code → Test traceability for an authentication module',
+      nodeCount: nodes.length,
+      edgeCount: edges.length,
+      nodeTypes,
+      edgeTypes,
+    },
+  };
+}

--- a/worlds/traceability-world/seed.edges.json
+++ b/worlds/traceability-world/seed.edges.json
@@ -1,0 +1,30 @@
+[
+  { "source": "spec:auth-login",       "target": "concept:credential-validation", "type": "defines",    "layer": "concept" },
+  { "source": "spec:auth-login",       "target": "concept:security-boundary",     "type": "defines",    "layer": "concept" },
+  { "source": "spec:session-expiry",   "target": "concept:session-lifecycle",     "type": "defines",    "layer": "concept" },
+  { "source": "spec:password-reset",   "target": "concept:password-recovery",     "type": "defines",    "layer": "concept" },
+
+  { "source": "concept:security-boundary",     "target": "invariant:no-plaintext",  "type": "constrains", "layer": "invariant" },
+  { "source": "concept:credential-validation", "target": "invariant:audit-trail",   "type": "constrains", "layer": "invariant" },
+  { "source": "concept:security-boundary",     "target": "concept:credential-validation", "type": "depends_on", "layer": "concept" },
+
+  { "source": "invariant:no-plaintext",  "target": "evidence:hash-tests",  "type": "proved_by", "layer": "provenance" },
+  { "source": "invariant:audit-trail",   "target": "evidence:login-tests", "type": "proved_by", "layer": "provenance" },
+
+  { "source": "code_artifact:authService",     "target": "spec:auth-login",       "type": "implements", "layer": "provenance" },
+  { "source": "code_artifact:sessionManager",  "target": "spec:session-expiry",   "type": "implements", "layer": "provenance" },
+  { "source": "code_artifact:lockoutHandler",  "target": "spec:account-lockout",  "type": "implements", "layer": "provenance" },
+  { "source": "code_artifact:resetHandler",    "target": "spec:password-reset",   "type": "implements", "layer": "provenance" },
+
+  { "source": "code_artifact:authService",     "target": "code_artifact:passwordHash",    "type": "depends_on", "layer": "code" },
+  { "source": "code_artifact:authService",     "target": "code_artifact:sessionManager",  "type": "depends_on", "layer": "code" },
+  { "source": "code_artifact:lockoutHandler",  "target": "code_artifact:authService",     "type": "depends_on", "layer": "code" },
+
+  { "source": "code_artifact:authService",     "target": "evidence:login-tests",    "type": "proved_by", "layer": "provenance" },
+  { "source": "code_artifact:sessionManager",  "target": "evidence:session-tests",  "type": "proved_by", "layer": "provenance" },
+  { "source": "code_artifact:lockoutHandler",  "target": "evidence:lockout-tests",  "type": "proved_by", "layer": "provenance" },
+  { "source": "code_artifact:passwordHash",    "target": "evidence:hash-tests",     "type": "proved_by", "layer": "provenance" },
+
+  { "source": "concept:credential-validation", "target": "evidence:login-tests",   "type": "proved_by", "layer": "provenance" },
+  { "source": "concept:session-lifecycle",     "target": "evidence:session-tests",  "type": "proved_by", "layer": "provenance" }
+]

--- a/worlds/traceability-world/seed.nodes.json
+++ b/worlds/traceability-world/seed.nodes.json
@@ -1,0 +1,132 @@
+[
+  {
+    "id": "spec:auth-login",
+    "type": "spec",
+    "title": "User Authentication via Credentials",
+    "status": "active"
+  },
+  {
+    "id": "spec:session-expiry",
+    "type": "spec",
+    "title": "Session Expiry After Inactivity",
+    "status": "active"
+  },
+  {
+    "id": "spec:account-lockout",
+    "type": "spec",
+    "title": "Account Lockout After Failed Attempts",
+    "status": "active"
+  },
+  {
+    "id": "spec:password-reset",
+    "type": "spec",
+    "title": "Password Reset via Email Link",
+    "status": "active"
+  },
+
+  {
+    "id": "concept:credential-validation",
+    "type": "concept",
+    "title": "Credential Validation",
+    "status": "active"
+  },
+  {
+    "id": "concept:session-lifecycle",
+    "type": "concept",
+    "title": "Session Lifecycle",
+    "status": "active"
+  },
+  {
+    "id": "concept:security-boundary",
+    "type": "concept",
+    "title": "Security Boundary",
+    "status": "active"
+  },
+  {
+    "id": "concept:password-recovery",
+    "type": "concept",
+    "title": "Password Recovery Flow",
+    "status": "active"
+  },
+  {
+    "id": "concept:test-coverage",
+    "type": "concept",
+    "title": "Test Coverage",
+    "status": "active"
+  },
+  {
+    "id": "concept:code-spec-alignment",
+    "type": "concept",
+    "title": "Code-Spec Alignment",
+    "status": "active"
+  },
+
+  {
+    "id": "invariant:no-plaintext",
+    "type": "invariant",
+    "title": "No Plaintext Password Storage",
+    "status": "active"
+  },
+  {
+    "id": "invariant:audit-trail",
+    "type": "invariant",
+    "title": "Authentication Event Audit Trail",
+    "status": "active"
+  },
+
+  {
+    "id": "code_artifact:authService",
+    "type": "code_artifact",
+    "title": "authService.js",
+    "status": "active"
+  },
+  {
+    "id": "code_artifact:sessionManager",
+    "type": "code_artifact",
+    "title": "sessionManager.js",
+    "status": "active"
+  },
+  {
+    "id": "code_artifact:passwordHash",
+    "type": "code_artifact",
+    "title": "passwordHash.js",
+    "status": "active"
+  },
+  {
+    "id": "code_artifact:lockoutHandler",
+    "type": "code_artifact",
+    "title": "lockoutHandler.js",
+    "status": "active"
+  },
+  {
+    "id": "code_artifact:resetHandler",
+    "type": "code_artifact",
+    "title": "resetHandler.js",
+    "status": "active"
+  },
+
+  {
+    "id": "evidence:login-tests",
+    "type": "evidence",
+    "title": "login.test.js",
+    "status": "active"
+  },
+  {
+    "id": "evidence:session-tests",
+    "type": "evidence",
+    "title": "session.test.js",
+    "status": "active"
+  },
+  {
+    "id": "evidence:hash-tests",
+    "type": "evidence",
+    "title": "hash.test.js",
+    "status": "active"
+  },
+  {
+    "id": "evidence:lockout-tests",
+    "type": "evidence",
+    "title": "lockout.test.js",
+    "status": "active"
+  }
+]


### PR DESCRIPTION
## Goal

Create the first public, engineering-recognizable proof case for Meaning Engine: a traceability reference world demonstrating spec → code → test traceability on an authentication module.

Closes #17

## Non-goals

- No new engine capabilities or core changes
- No external tool integration (Jira, CI, etc.)
- No claim of industrial-scale readiness
- No ALM/compliance framing

## What the case demonstrates

A compact authentication module graph (21 nodes, 22 edges) with 5 entity types (spec, concept, invariant, code_artifact, evidence) and 5 reproducible scenarios:

| Scenario | Demonstrates | Result |
|----------|-------------|--------|
| S1: Spec → Evidence trace | Directed traceability through concept layer | 2-hop path found |
| S2: Rival paths | Compare detects concept-heavy vs code-heavy paths | 2 rival paths, 2 clusters |
| S3: Gap detection | Password-reset has code but no tests | No path + bridge candidates |
| S4: Invariant enforcement | Invariants trace directly to evidence | 1-hop proved_by |
| S5: Focused projection | Local neighborhood of a requirement | 4 nodes, 3 neighbors |

## What the case does NOT demonstrate

- Large-scale traceability (21-node world, not thousands)
- Real-time graph updates
- External tool integration
- Automated gap remediation
- Industrial compliance

## Acceptance checklist

- [x] Traceability world exists (21N/22E)
- [x] Demo script runs 5 scenarios (`demo.js`)
- [x] 25 automated tests pass
- [x] Explanatory doc exists (`TRACEABILITY_CASE.md`)
- [x] Gap detection demonstrated (password-reset)
- [x] Rival path detection demonstrated (concept vs code)
- [x] All 930 tests pass
- [x] No runtime/API changes

## Files changed

- `worlds/traceability-world/seed.nodes.json` (new) — 21 nodes
- `worlds/traceability-world/seed.edges.json` (new) — 22 edges
- `worlds/traceability-world/loader.js` (new) — world loader
- `worlds/traceability-world/demo.js` (new) — demo script with 5 scenarios
- `worlds/traceability-world/__tests__/traceabilityWorld.test.js` (new) — 25 tests
- `worlds/traceability-world/TRACEABILITY_CASE.md` (new) — explanatory documentation
