### PR TITLE
F1: Add OSS governance docs, issue/PR templates, and feedback channel

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,40 @@
+---
+name: Bug Report
+about: Report a reproducible problem
+title: "[Bug] "
+labels: bug
+assignees: ''
+---
+
+## Description
+
+A clear, concise description of the bug.
+
+## Steps to reproduce
+
+1. ...
+2. ...
+3. ...
+
+## Expected behavior
+
+What you expected to happen.
+
+## Actual behavior
+
+What actually happened. Include error messages or output if applicable.
+
+## Environment
+
+- Node.js version: 
+- OS: 
+- Meaning Engine version/commit: 
+
+## Reproducibility
+
+- [ ] I can reproduce this consistently
+- [ ] This is intermittent
+
+## Additional context
+
+Any additional information (logs, screenshots, related issues).

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,39 @@
+---
+name: Feature Proposal
+about: Propose a new capability or improvement
+title: "[Proposal] "
+labels: proposal
+assignees: ''
+---
+
+## Problem or motivation
+
+What problem does this solve? Why is this needed?
+
+## Proposed solution
+
+A clear description of what you'd like to happen.
+
+## Scope
+
+- **What this changes**: 
+- **What this does NOT change**: 
+
+## Impact on public promise
+
+- [ ] This changes the public API surface
+- [ ] This adds a new public guarantee
+- [ ] This is internal/experimental only
+- [ ] I'm not sure — please advise
+
+## Alternatives considered
+
+What other approaches did you consider?
+
+## Additional context
+
+Any additional information, references, or examples.
+
+---
+
+*Note: Meaning Engine maintains strict truthful-claim discipline. Proposals that would overstate the engine's capabilities or change the public promise require explicit discussion. See [CLAIMS_AND_NONCLAIMS.md](../docs/presentation/CLAIMS_AND_NONCLAIMS.md).*

--- a/.github/ISSUE_TEMPLATE/presentation_feedback.md
+++ b/.github/ISSUE_TEMPLATE/presentation_feedback.md
@@ -1,0 +1,62 @@
+---
+name: Presentation / Dry-Run Feedback
+about: Structured feedback after reading or watching Meaning Engine presentation materials
+title: "[Feedback] "
+labels: feedback
+assignees: ''
+---
+
+## Context
+
+- **What did you review?** (check all that apply)
+  - [ ] README / repo overview
+  - [ ] Presentation narrative (`docs/presentation/PRESENTATION_NARRATIVE.md`)
+  - [ ] Demo output (`worlds/traceability-world/demo.js`)
+  - [ ] Talk / live presentation
+  - [ ] Other: 
+
+- **Your role/background** (optional, helps us calibrate):
+
+
+## Clarity
+
+1. **What was clear?** What did you understand quickly?
+
+
+2. **What was confusing?** Where did you get lost or need to re-read?
+
+
+3. **What was missing?** What question did you have that wasn't answered?
+
+
+## Claims and credibility
+
+4. **Did anything feel overclaimed?** Where did the materials promise more than what was demonstrated?
+
+
+5. **Did anything feel underclaimed?** Where did the materials undersell something that seemed genuinely strong?
+
+
+## Engineering relevance
+
+6. **Would you use this?** If yes, for what? If no, what would need to change?
+
+
+7. **What's the strongest objection you'd raise?**
+
+
+## Suggestions
+
+8. **One thing to change first:**
+
+
+9. **One thing to keep exactly as is:**
+
+
+## Additional observations
+
+Anything else — concrete observations preferred over general opinions.
+
+---
+
+*Thank you for your feedback. We prefer specific, concrete observations over general impressions. See [docs/FEEDBACK.md](../docs/FEEDBACK.md) for more context on what kinds of feedback are most useful.*

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,38 @@
+## Goal
+
+What does this PR accomplish? (1–2 sentences)
+
+## Non-goals
+
+What is explicitly out of scope for this PR?
+
+## Changes
+
+- 
+
+## Tests
+
+- [ ] `npm test` passes locally (930+ tests)
+- [ ] New/changed behavior has corresponding tests
+- [ ] No test files were removed
+
+## Public promise impact
+
+- [ ] This PR does NOT change the public API surface or public guarantees
+- [ ] This PR changes the public API surface — describe below:
+  - What changed: 
+  - Why: 
+
+## Checklist
+
+- [ ] Commit messages are in English
+- [ ] PR has a single, focused goal
+- [ ] No new runtime dependencies added (or justified below)
+- [ ] Documentation updated if needed
+
+## Related issues
+
+Closes #
+
+## Additional context
+

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,33 @@
+# Code of Conduct
+
+## Our Pledge
+
+We are committed to making participation in this project a respectful and productive experience for everyone, regardless of experience level, background, or perspective.
+
+## Standards
+
+**Expected behavior:**
+
+- Use clear, precise technical language
+- Provide concrete observations over general opinions
+- Accept constructive criticism gracefully
+- Prioritize what's best for the project's technical integrity
+
+**Unacceptable behavior:**
+
+- Personal attacks or derogatory comments
+- Harassment in any form
+- Publishing private information without consent
+- Conduct that would be considered inappropriate in a professional engineering setting
+
+## Scope
+
+This code of conduct applies to all project spaces: issues, pull requests, discussions, and any related communication channels.
+
+## Enforcement
+
+Instances of unacceptable behavior may be reported to the project maintainer. All reports will be reviewed. The maintainer reserves the right to remove, edit, or reject contributions that violate this code of conduct.
+
+## Attribution
+
+This code of conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org/), version 2.1.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,67 @@
+# Contributing to Meaning Engine
+
+Thank you for your interest in contributing. This document explains how to engage with the project effectively.
+
+---
+
+## How to open an issue
+
+1. Check [existing issues](https://github.com/utemix-org/meaning-engine/issues) to avoid duplicates.
+2. Use the appropriate issue template:
+   - **Bug report** — for reproducible problems
+   - **Feature proposal** — for new capabilities (read the scope note below first)
+   - **Presentation feedback** — for structured feedback after reading/watching presentation materials
+3. Provide concrete, specific information. Observations are more useful than opinions.
+
+## How to open a pull request
+
+1. **Open an issue first** describing what you want to change and why.
+2. Fork the repo and create a branch from `main`.
+3. Make your changes. Keep PRs small and focused — one goal per PR.
+4. Run the test suite locally:
+   ```bash
+   npm ci
+   npm test        # all 930+ tests must pass
+   ```
+5. Open a PR using the pull request template. Fill in all sections.
+
+### Required checks before merge
+
+All PRs must pass 4 CI checks before merging into `main`:
+
+| Check | What it does |
+|-------|-------------|
+| `test (18.x)` | Tests on Node.js 18 |
+| `test (20.x)` | Tests on Node.js 20 + coverage |
+| `test (22.x)` | Tests on Node.js 22 |
+| `package-check` | Version consistency, types, npm pack, demo verification |
+
+See [docs/PROCESS_CI_AND_MERGE_GATES.md](./docs/PROCESS_CI_AND_MERGE_GATES.md) for full merge gate policy.
+
+## Repo conventions
+
+- **Language**: all code, comments, commit messages, and documentation in English
+- **Tests**: every behavioral change must include or update tests
+- **Commit messages**: concise, in English, focused on "why" not "what"
+- **PRs**: must state goal, non-goals, and whether the change affects the public promise
+- **No scope creep**: each PR should do one thing well
+
+## What we welcome
+
+- Bug fixes with reproducible test cases
+- Test coverage improvements
+- Documentation clarifications
+- New reference worlds (see [MAKE_YOUR_FIRST_WORLD.md](./docs/MAKE_YOUR_FIRST_WORLD.md))
+- Structured feedback on presentation materials (see [docs/FEEDBACK.md](./docs/FEEDBACK.md))
+
+## What to avoid
+
+- Large, multi-goal PRs
+- Changes to the public API surface without prior discussion
+- New runtime dependencies without strong justification
+- Claims or documentation that overstates what the engine does (see [CLAIMS_AND_NONCLAIMS.md](./docs/presentation/CLAIMS_AND_NONCLAIMS.md))
+- Adding experimental features to the stable surface
+
+## Public promise discipline
+
+Meaning Engine maintains strict truthful-claim discipline. If your contribution changes what the engine promises publicly, state this explicitly in the PR description. See [API_SURFACE_POLICY.md](./docs/API_SURFACE_POLICY.md) for the public/experimental boundary.

--- a/README.md
+++ b/README.md
@@ -176,7 +176,15 @@ npm run test:coverage # with coverage report
 
 ## Contributing
 
-See [API_SURFACE_POLICY.md](./docs/API_SURFACE_POLICY.md) for the public/experimental/internal classification.
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for how to open issues, submit PRs, and repo conventions. See [API_SURFACE_POLICY.md](./docs/API_SURFACE_POLICY.md) for the public/experimental/internal classification.
+
+## Feedback
+
+We welcome structured feedback from engineers. See [docs/FEEDBACK.md](./docs/FEEDBACK.md) for what kinds of feedback are most useful and how to submit it. You can also [open a feedback issue directly](https://github.com/utemix-org/meaning-engine/issues/new?template=presentation_feedback.md).
+
+## Code of Conduct
+
+This project follows a [Code of Conduct](./CODE_OF_CONDUCT.md).
 
 ## License
 

--- a/docs/FEEDBACK.md
+++ b/docs/FEEDBACK.md
@@ -1,0 +1,78 @@
+# How to Give Feedback — Meaning Engine
+
+We actively seek structured feedback from engineers who read, watch, or interact with Meaning Engine materials. This page explains what feedback is most useful and how to submit it.
+
+---
+
+## What kind of feedback we want
+
+We are looking for **concrete observations**, not general impressions.
+
+### Most useful
+
+- "I didn't understand what 'computational substrate' means until I read the demo output"
+- "The gap detection demo was the most convincing part"
+- "I would object that 21 nodes is too small to prove anything"
+- "The Q&A section doesn't address [specific question]"
+- "This claim in the narrative feels too strong: [exact quote]"
+
+### Less useful
+
+- "Looks good"
+- "Interesting project"
+- "Maybe add more features"
+
+### Specifically, we want to know
+
+1. **Where were you confused?** Which part of the materials was unclear or required re-reading?
+2. **Where did we overclaim?** Where did the materials promise more than what was demonstrated?
+3. **Where did we underclaim?** Where did we undersell something genuinely strong?
+4. **What objection would you raise?** If you were reviewing this in an engineering meeting, what would you challenge?
+5. **What's missing?** What question did you have that wasn't answered?
+
+---
+
+## How to submit feedback
+
+### Option 1: GitHub Issue (preferred)
+
+Open a new issue using the **Presentation / Dry-Run Feedback** template:
+
+[**Open feedback issue**](https://github.com/utemix-org/meaning-engine/issues/new?template=presentation_feedback.md)
+
+The template includes a short structured questionnaire (9 prompts). Fill in what's relevant — you don't need to answer every question.
+
+### Option 2: Informal
+
+If you prefer not to open a GitHub issue, you can share observations in any format with the project maintainer. We'll capture and attribute the feedback appropriately.
+
+---
+
+## What happens with your feedback
+
+- Feedback is reviewed and categorized (content / delivery / demo / objection).
+- Concrete observations may lead to narrow improvements in the presentation materials.
+- We will not invent feedback that wasn't given.
+- We will not claim community endorsement based on individual feedback.
+
+---
+
+## What we are NOT asking for
+
+- We are not soliciting feature requests through this channel (use the feature proposal template for that).
+- We are not asking for approval or endorsement.
+- We are not promising response SLAs.
+- We do not have an existing community — this is a pre-production project seeking early engineering feedback.
+
+---
+
+## Materials available for review
+
+| Material | Location | What it covers |
+|----------|----------|---------------|
+| Project overview | [README.md](../README.md) | What ME is, what it isn't, quick start |
+| Presentation narrative | [docs/presentation/PRESENTATION_NARRATIVE.md](./presentation/PRESENTATION_NARRATIVE.md) | Full engineering story |
+| Claims and non-claims | [docs/presentation/CLAIMS_AND_NONCLAIMS.md](./presentation/CLAIMS_AND_NONCLAIMS.md) | What we claim, what we don't |
+| Live demo | `node --experimental-vm-modules worlds/traceability-world/demo.js` | 5 scenarios on a 21-node graph |
+| Test suite | `npm test` | 930+ tests, 41 files |
+| Benchmark data | [docs/OPERATIONAL_LIMITS.md](./OPERATIONAL_LIMITS.md) | Measured performance + sharp edges |


### PR DESCRIPTION
## Goal

Add minimal open-source governance and structured feedback channel for Meaning Engine, enabling external engineers to engage with the project safely and submit structured feedback on presentation materials.

## Non-goals

- No large governance bureaucracy
- No new runtime features or API changes
- No response SLAs promised
- No claim of existing community

## Changes

- `CODE_OF_CONDUCT.md` — Contributor Covenant 2.1 adapted, concise
- `CONTRIBUTING.md` — how to open issues, submit PRs, required CI checks, repo conventions, scope discipline
- `.github/ISSUE_TEMPLATE/bug_report.md` — structured bug reporting
- `.github/ISSUE_TEMPLATE/feature_request.md` — feature proposals with claim-impact awareness
- `.github/ISSUE_TEMPLATE/presentation_feedback.md` — 9-prompt structured questionnaire for presentation/dry-run feedback
- `.github/pull_request_template.md` — goal/non-goals, tests, claim impact, checklist
- `docs/FEEDBACK.md` — public feedback entrypoint with materials index, submission guidance, and what-happens-next
- `README.md` — added Contributing, Feedback, and Code of Conduct sections

## Tests

- [x] `npm test` passes locally (930/930 tests)
- [x] No runtime/API behavior changes
- [x] No new dependencies

## Public promise impact

- [x] This PR does NOT change the public API surface or public guarantees

## Checklist

- [x] Commit messages in English
- [x] Single focused goal
- [x] No new runtime dependencies
- [x] Documentation added

## Related issues

Closes #28

Tracking: `OPUS_TASK__ME_READINESS__F1__OPEN_SOURCE_CONTRIBUTING_GOVERNANCE_AND_FEEDBACK_CHANNEL`
